### PR TITLE
Include GFA assembly graphs in results

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -1474,7 +1474,8 @@ process SPADES {
                                                                  ch_spades_blast,
                                                                  ch_spades_abacas,
                                                                  ch_spades_plasmidid
-    set val(sample), val(single_end), file("*scaffolds.fa"), file("*assembly.gfa") into ch_spades_graph
+    file "*assembly.gfa"
+
 
     script:
     input_reads = single_end ? "-s $reads" : "-1 ${reads[0]} -2 ${reads[1]}"

--- a/main.nf
+++ b/main.nf
@@ -1474,6 +1474,7 @@ process SPADES {
                                                                  ch_spades_blast,
                                                                  ch_spades_abacas,
                                                                  ch_spades_plasmidid
+    set val(sample), val(single_end), file("*scaffolds.fa"), file("*assembly.gfa") into ch_spades_graph
 
     script:
     input_reads = single_end ? "-s $reads" : "-1 ${reads[0]} -2 ${reads[1]}"
@@ -1483,6 +1484,7 @@ process SPADES {
         $input_reads \\
         -o ./
     mv scaffolds.fasta ${sample}.scaffolds.fa
+    mv assembly_graph_with_scaffolds.gfa ${sample}.assembly.gfa
     """
 }
 
@@ -1630,6 +1632,7 @@ process METASPADES {
                                                                  ch_metaspades_blast,
                                                                  ch_metaspades_abacas,
                                                                  ch_metaspades_plasmidid
+    set val(sample), val(single_end), file("*scaffolds.fa"), file("*assembly.gfa") into ch_metaspades_graph
 
     script:
     """
@@ -1640,6 +1643,7 @@ process METASPADES {
         -2 ${reads[1]} \\
         -o ./
     mv scaffolds.fasta ${sample}.meta.scaffolds.fa
+    mv assembly_graph_with_scaffolds.gfa ${sample}.meta.assembly.gfa
     """
 }
 
@@ -1787,6 +1791,7 @@ process UNICYCLER {
                                                                 ch_unicycler_blast,
                                                                 ch_unicycler_abacas,
                                                                 ch_unicycler_plasmidid
+    set val(sample), val(single_end), file("*assembly.fa"), file("*assembly.gfa") into ch_unicycler_graph
 
     script:
     input_reads = single_end ? "-s $reads" : "-1 ${reads[0]} -2 ${reads[1]}"
@@ -1796,6 +1801,7 @@ process UNICYCLER {
         $input_reads \\
         --out ./
     mv assembly.fasta ${sample}.assembly.fa
+    mv assembly.gfa ${sample}.assembly.gfa
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -1633,7 +1633,8 @@ process METASPADES {
                                                                  ch_metaspades_blast,
                                                                  ch_metaspades_abacas,
                                                                  ch_metaspades_plasmidid
-    set val(sample), val(single_end), file("*scaffolds.fa"), file("*assembly.gfa") into ch_metaspades_graph
+    file "*assembly.gfa"
+
 
     script:
     """

--- a/main.nf
+++ b/main.nf
@@ -1793,7 +1793,8 @@ process UNICYCLER {
                                                                 ch_unicycler_blast,
                                                                 ch_unicycler_abacas,
                                                                 ch_unicycler_plasmidid
-    set val(sample), val(single_end), file("*assembly.fa"), file("*assembly.gfa") into ch_unicycler_graph
+    file "*assembly.gfa"
+
 
     script:
     input_reads = single_end ? "-s $reads" : "-1 ${reads[0]} -2 ${reads[1]}"


### PR DESCRIPTION
Fixes #46 

I also wonder, for consistency's sake, if the `${sample}.scaffolds.fa` and `${sample}.meta.scaffolds.fa` files in results for spades and metaspades respectively should be renamed to match `${sample}.assembly.fa` from unicycler?


## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/viralrecon branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/viralrecon)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/viralrecon/tree/master/.github/CONTRIBUTING.md)