### PR TITLE
Add bandage visualization of GFA assembly graphs

### DIFF
--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -10,6 +10,9 @@
 * [ABACAS](https://www.ncbi.nlm.nih.gov/pubmed/19497936/)
   > Assefa S, Keane TM, Otto TD, Newbold C, Berriman M. ABACAS: algorithm-based automatic contiguation of assembled sequences. Bioinformatics. 2009 Aug 1;25(15):1968-9. doi: 10.1093/bioinformatics/btp347. Epub 2009 Jun 3. PubMed PMID: 19497936; PubMed Central PMCID: PMC2712343.
 
+* [Bandage](https://www.ncbi.nlm.nih.gov/pubmed/26099265)
+  > Wick R.R., Schultz M.B., Zobel J. & Holt K.E. Bandage: interactive visualisation of de novo genome assemblies. Bioinformatics, 31(20), 3350-3352. doi: 10.1093/bioinformatics/btv383. PubMed PMID: 26099265; PubMed Central PCMID: PMC4595904.
+
 * [BCFtools](https://www.ncbi.nlm.nih.gov/pubmed/21903627/)
   > Li H. A statistical framework for SNP calling, mutation discovery, association mapping and population genetical parameter estimation from sequencing data. Bioinformatics. 2011 Nov 1;27(21):2987-93. doi: 10.1093/bioinformatics/btr509. Epub 2011 Sep 8. PubMed PMID: 21903627; PubMed Central PMCID: PMC3198575.
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -274,6 +274,8 @@ We used a Kraken2 database in this workflow to filter out reads specific to the 
 * `assembly/spades/`
   * `*.scaffolds.fa`: SPAdes scaffold assembly.
   * `*.assembly.gfa`: SPAdes assembly in GFA format.
+  * `*.assembly.png`: SPAdes assembly in GFA format visualized by Bandage in PNG format.
+  * `*.assembly.svg`: SPAdes assembly in GFA format visualized by Bandage in SVG format.
 
 ### metaSPAdes
 
@@ -284,6 +286,8 @@ We used a Kraken2 database in this workflow to filter out reads specific to the 
 * `assembly/metaspades/`
   * `*.scaffolds.fa`: metaSPAdes scaffold assembly.
   * `*.assembly.gfa`: metaSPAdes assembly in GFA format.
+  * `*.assembly.png`: metaSPAdes assembly in GFA format visualized by Bandage in PNG format.
+  * `*.assembly.svg`: metaSPAdes assembly in GFA format visualized by Bandage in SVG format.
 
 ### Unicycler
 
@@ -294,6 +298,8 @@ We used a Kraken2 database in this workflow to filter out reads specific to the 
 * `assembly/unicycler/`
   * `*.scaffolds.fa`: Unicycler scaffold assembly.
   * `*.assembly.gfa`: Unicycler assembly in GFA format.
+  * `*.assembly.png`: Unicycler assembly in GFA format visualized by Bandage in PNG format.
+  * `*.assembly.png`: Unicycler assembly in GFA format visualized by Bandage in SVG format.
 
 ### minia
 
@@ -306,12 +312,14 @@ TODO: Add documentation here about [minia](https://github.com/GATB/minia).
 
 ### Minimap2, seqwish, vg
 
-TODO: Add documentation here about [`Minimap2`](https://github.com/lh3/minimap2), [`seqwish`](https://github.com/ekg/seqwish), [`vg`](https://github.com/vgteam/vg).
+TODO: Add documentation here about [`Minimap2`](https://github.com/lh3/minimap2), [`seqwish`](https://github.com/ekg/seqwish), [`vg`](https://github.com/vgteam/vg), [`Bandage`](https://github.com/rrwick/Bandage).
 
 **Output files:**
 
 * `assembly/<ASSEMBLER>/variants/`
   * `*.gfa`: minia scaffold assembly.
+  * `*.png`: minia scaffold assembly visualized by Bandage in PNG format.
+  * `*.svg`: minia scaffold assembly visualized by Bandage in SVG format.
   * `*.paf`: minia scaffold assembly.
   * `*.vcf.gz`: VCF file with variant annotations.
   * `*.vcf.gz.tbi`: Index for VCF file with variant annotations.

--- a/environment.yml
+++ b/environment.yml
@@ -47,4 +47,5 @@ dependencies:
   - bioconda::quast=5.0.2
   - bioconda::blast=2.9.0
   - bioconda::plasmidid=1.5.2
+  - bioconda::bandage=0.8.1
   - hcc::abacas=1.3.1

--- a/main.nf
+++ b/main.nf
@@ -1480,7 +1480,7 @@ process SPADES {
                                                                  ch_spades_abacas,
                                                                  ch_spades_plasmidid,
                                                                  ch_spades_quast
-    file "*assembly.gfa"
+    file "*assembly.{gfa,png,svg}"
 
 
     script:
@@ -1492,6 +1492,9 @@ process SPADES {
         -o ./
     mv scaffolds.fasta ${sample}.scaffolds.fa
     mv assembly_graph_with_scaffolds.gfa ${sample}.assembly.gfa
+
+    Bandage image ${sample}.assembly.gfa ${sample}.assembly.png --height 1000
+    Bandage image ${sample}.assembly.gfa ${sample}.assembly.svg --height 1000
     """
 }
 
@@ -1521,7 +1524,7 @@ process SPADES_VG {
     output:
     set val(sample), val(single_end), file("*.vcf.gz*") into ch_spades_vg_vcf
     file "*.bcftools_stats.txt" into ch_spades_vg_bcftools_mqc
-    file "*.{paf,gfa,vg,xg}"
+    file "*.{paf,gfa,vg,xg,png,svg}"
 
     script:
     """
@@ -1538,6 +1541,9 @@ process SPADES_VG {
         | bgzip -c > ${sample}.vcf.gz
     tabix -p vcf -f ${sample}.vcf.gz
     bcftools stats ${sample}.vcf.gz > ${sample}.bcftools_stats.txt
+
+    Bandage image ${sample}.gfa ${sample}.png --height 1000
+    Bandage image ${sample}.gfa ${sample}.svg --height 1000
     """
 }
 
@@ -1740,7 +1746,7 @@ process METASPADES {
                                                                  ch_metaspades_abacas,
                                                                  ch_metaspades_plasmidid,
                                                                  ch_metaspades_quast
-    file "*assembly.gfa"
+    file "*assembly.{gfa,png,svg}"
 
 
     script:
@@ -1753,6 +1759,9 @@ process METASPADES {
         -o ./
     mv scaffolds.fasta ${sample}.scaffolds.fa
     mv assembly_graph_with_scaffolds.gfa ${sample}.assembly.gfa
+
+    Bandage image ${sample}.assembly.gfa ${sample}.assembly.png --height 1000
+    Bandage image ${sample}.assembly.gfa ${sample}.assembly.svg --height 1000
     """
 }
 
@@ -1778,7 +1787,7 @@ process METASPADES_VG {
     output:
     set val(sample), val(single_end), file("*.vcf.gz*") into ch_metaspades_vg_vcf
     file "*.bcftools_stats.txt" into ch_metaspades_vg_bcftools_mqc
-    file "*.{paf,gfa,vg,xg}"
+    file "*.{paf,gfa,vg,xg,png,svg}"
 
     script:
     """
@@ -1795,6 +1804,9 @@ process METASPADES_VG {
         | bgzip -c > ${sample}.vcf.gz
     tabix -p vcf -f ${sample}.vcf.gz
     bcftools stats ${sample}.vcf.gz > ${sample}.bcftools_stats.txt
+
+    Bandage image ${sample}.gfa ${sample}.png --height 1000
+    Bandage image ${sample}.gfa ${sample}.svg --height 1000
     """
 }
 
@@ -1997,7 +2009,7 @@ process UNICYCLER {
                                                                  ch_unicycler_abacas,
                                                                  ch_unicycler_plasmidid,
                                                                  ch_unicycler_quast
-    file "*assembly.gfa"
+    file "*assembly.{gfa,png,svg}"
 
 
     script:
@@ -2009,6 +2021,9 @@ process UNICYCLER {
         --out ./
     mv assembly.fasta ${sample}.scaffolds.fa
     mv assembly.gfa ${sample}.assembly.gfa
+
+    Bandage image ${sample}.assembly.gfa ${sample}.assembly.png --height 1000
+    Bandage image ${sample}.assembly.gfa ${sample}.assembly.svg --height 1000
     """
 }
 
@@ -2034,7 +2049,7 @@ process UNICYCLER_VG {
     output:
     set val(sample), val(single_end), file("*.vcf.gz*") into ch_unicycler_vg_vcf
     file "*.bcftools_stats.txt" into ch_unicycler_vg_bcftools_mqc
-    file "*.{paf,gfa,vg,xg}"
+    file "*.{paf,gfa,vg,xg,png,svg}"
 
     script:
     """
@@ -2051,6 +2066,9 @@ process UNICYCLER_VG {
         | bgzip -c > ${sample}.vcf.gz
     tabix -p vcf -f ${sample}.vcf.gz
     bcftools stats ${sample}.vcf.gz > ${sample}.bcftools_stats.txt
+
+    Bandage image ${sample}.gfa ${sample}.png --height 1000
+    Bandage image ${sample}.gfa ${sample}.svg --height 1000
     """
 }
 
@@ -2290,7 +2308,7 @@ process MINIA_VG {
     output:
     set val(sample), val(single_end), file("*.vcf.gz*") into ch_minia_vg_vcf
     file "*.bcftools_stats.txt" into ch_minia_vg_bcftools_mqc
-    file "*.{paf,gfa,vg,xg}"
+    file "*.{paf,gfa,vg,xg,png,svg}"
 
     script:
     """
@@ -2307,6 +2325,9 @@ process MINIA_VG {
         | bgzip -c > ${sample}.vcf.gz
     tabix -p vcf -f ${sample}.vcf.gz
     bcftools stats ${sample}.vcf.gz > ${sample}.bcftools_stats.txt
+
+    Bandage image ${sample}.gfa ${sample}.png --height 1000
+    Bandage image ${sample}.gfa ${sample}.svg --height 1000
     """
 }
 


### PR DESCRIPTION
Depends on #64

This works for me using the bandage:0.8.1 Biocontainers Docker image in a separate process with the `container` label; I am not sure how to test this pull request in Docker without creating a new Docker image via #64 (the Conda install via `environment.yml` doesn't go well for me locally).


## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/viralrecon branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/viralrecon)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/viralrecon/tree/master/.github/CONTRIBUTING.md)