### PR TITLE
Workaround vg deconstruct failures by adding vg snarls step

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -2061,7 +2061,8 @@ process SPADES_VG {
     samtools faidx $fasta
     for chrom in `cat ${fasta}.fai | cut -f1`
     do
-        vg deconstruct -p \$chrom ${sample}.xg --threads $task.cpus \\
+        vg snarls ${sample}.xg > ${sample}.snarls
+        vg deconstruct -p \$chrom ${sample}.xg -r ${sample}.snarls --threads $task.cpus \\
             | bcftools sort -O v -T ./ \\
             | bgzip -c > ${sample}.\$chrom.vcf.gz
     done
@@ -2341,7 +2342,8 @@ process METASPADES_VG {
     samtools faidx $fasta
     for chrom in `cat ${fasta}.fai | cut -f1`
     do
-        vg deconstruct -p \$chrom ${sample}.xg --threads $task.cpus \\
+        vg snarls ${sample}.xg > ${sample}.snarls
+        vg deconstruct -p \$chrom ${sample}.xg -r ${sample}.snarls --threads $task.cpus \\
             | bcftools sort -O v -T ./ \\
             | bgzip -c > ${sample}.\$chrom.vcf.gz
     done
@@ -2619,7 +2621,8 @@ process UNICYCLER_VG {
     samtools faidx $fasta
     for chrom in `cat ${fasta}.fai | cut -f1`
     do
-        vg deconstruct -p \$chrom ${sample}.xg --threads $task.cpus \\
+        vg snarls ${sample}.xg > ${sample}.snarls
+        vg deconstruct -p \$chrom ${sample}.xg -r ${sample}.snarls --threads $task.cpus \\
             | bcftools sort -O v -T ./ \\
             | bgzip -c > ${sample}.\$chrom.vcf.gz
     done
@@ -2886,7 +2889,8 @@ process MINIA_VG {
     samtools faidx $fasta
     for chrom in `cat ${fasta}.fai | cut -f1`
     do
-        vg deconstruct -p \$chrom ${sample}.xg --threads $task.cpus \\
+        vg snarls ${sample}.xg > ${sample}.snarls
+        vg deconstruct -p \$chrom ${sample}.xg -r ${sample}.snarls --threads $task.cpus \\
             | bcftools sort -O v -T ./ \\
             | bgzip -c > ${sample}.\$chrom.vcf.gz
     done

--- a/main.nf
+++ b/main.nf
@@ -2059,9 +2059,9 @@ process SPADES_VG {
     vg convert -x ${sample}.vg > ${sample}.xg
 
     samtools faidx $fasta
+    vg snarls ${sample}.xg > ${sample}.snarls
     for chrom in `cat ${fasta}.fai | cut -f1`
     do
-        vg snarls ${sample}.xg > ${sample}.snarls
         vg deconstruct -p \$chrom ${sample}.xg -r ${sample}.snarls --threads $task.cpus \\
             | bcftools sort -O v -T ./ \\
             | bgzip -c > ${sample}.\$chrom.vcf.gz
@@ -2340,9 +2340,9 @@ process METASPADES_VG {
     vg convert -x ${sample}.vg > ${sample}.xg
 
     samtools faidx $fasta
+    vg snarls ${sample}.xg > ${sample}.snarls
     for chrom in `cat ${fasta}.fai | cut -f1`
     do
-        vg snarls ${sample}.xg > ${sample}.snarls
         vg deconstruct -p \$chrom ${sample}.xg -r ${sample}.snarls --threads $task.cpus \\
             | bcftools sort -O v -T ./ \\
             | bgzip -c > ${sample}.\$chrom.vcf.gz
@@ -2619,9 +2619,9 @@ process UNICYCLER_VG {
     vg convert -x ${sample}.vg > ${sample}.xg
 
     samtools faidx $fasta
+    vg snarls ${sample}.xg > ${sample}.snarls
     for chrom in `cat ${fasta}.fai | cut -f1`
     do
-        vg snarls ${sample}.xg > ${sample}.snarls
         vg deconstruct -p \$chrom ${sample}.xg -r ${sample}.snarls --threads $task.cpus \\
             | bcftools sort -O v -T ./ \\
             | bgzip -c > ${sample}.\$chrom.vcf.gz
@@ -2887,9 +2887,9 @@ process MINIA_VG {
     vg convert -x ${sample}.vg > ${sample}.xg
 
     samtools faidx $fasta
+    vg snarls ${sample}.xg > ${sample}.snarls
     for chrom in `cat ${fasta}.fai | cut -f1`
     do
-        vg snarls ${sample}.xg > ${sample}.snarls
         vg deconstruct -p \$chrom ${sample}.xg -r ${sample}.snarls --threads $task.cpus \\
             | bcftools sort -O v -T ./ \\
             | bgzip -c > ${sample}.\$chrom.vcf.gz


### PR DESCRIPTION
With these changes, all the `_VG` steps pass but one sample fails the `MINIA_PLASMIDID` step due to poor assembly (only one contig that gets filtered out for being too short).


## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/viralrecon branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/viralrecon)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/viralrecon/tree/master/.github/CONTRIBUTING.md)