### PR TITLE
GitHub Actions CI - add workflow cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           sudo mv nextflow /usr/local/bin/
 
       - name: Run pipeline with test data
-        run: nextflow run ${GITHUB_WORKSPACE} -profile test,docker -resume
+        run: nextflow run . -profile test,docker -resume
 
   parameters:
     name: Test workflow parameters
@@ -112,7 +112,7 @@ jobs:
           sudo mv nextflow /usr/local/bin/
 
       - name: Run pipeline with test amplicon data with various options
-        run: nextflow run ${GITHUB_WORKSPACE} -profile test,docker ${{ matrix.parameters }} -resume
+        run: nextflow run . -profile test,docker ${{ matrix.parameters }} -resume
 
   test_sra:
     name: Test SRA workflow
@@ -163,7 +163,7 @@ jobs:
           sudo mv nextflow /usr/local/bin/
 
       - name: Run pipeline with minimal data via SRA ids and various options
-        run: nextflow run ${GITHUB_WORKSPACE} -profile test_sra,docker ${{ matrix.parameters }} -resume
+        run: nextflow run . -profile test_sra,docker ${{ matrix.parameters }} -resume
 
   test_sispa:
     name: Test SISPA workflow
@@ -214,7 +214,7 @@ jobs:
           sudo mv nextflow /usr/local/bin/
 
       - name: Run pipeline with minimal SISPA data and various options
-        run: nextflow run ${GITHUB_WORKSPACE} -profile test_sispa,docker ${{ matrix.parameters }} -resume
+        run: nextflow run . -profile test_sispa,docker ${{ matrix.parameters }} -resume
 
   push_dockerhub:
     name: Push new Docker image to Docker Hub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Run pipeline with test data
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test,docker
+          nextflow run ${GITHUB_WORKSPACE} -profile test,docker -resume
 
   parameters:
     name: Test workflow parameters
@@ -114,7 +114,7 @@ jobs:
 
       - name: Run pipeline with test amplicon data with various options
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test,docker ${{ matrix.parameters }}
+          nextflow run ${GITHUB_WORKSPACE} -profile test,docker ${{ matrix.parameters }} -resume
 
   test_sra:
     name: Test SRA workflow
@@ -166,7 +166,7 @@ jobs:
 
       - name: Run pipeline with minimal data via SRA ids and various options
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test_sra,docker ${{ matrix.parameters }}
+          nextflow run ${GITHUB_WORKSPACE} -profile test_sra,docker ${{ matrix.parameters }} -resume
 
   test_sispa:
     name: Test SISPA workflow
@@ -218,7 +218,7 @@ jobs:
 
       - name: Run pipeline with minimal SISPA data and various options
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test_sispa,docker ${{ matrix.parameters }}
+          nextflow run ${GITHUB_WORKSPACE} -profile test_sispa,docker ${{ matrix.parameters }} -resume
 
   push_dockerhub:
     name: Push new Docker image to Docker Hub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,10 @@ jobs:
           path: |
             work
             .nextflow
-          key: nfdata-${{ matrix.nxf_ver }}-${{ github.sha }}
+          key: nfdata-test-${{ matrix.nxf_ver }}-${{ github.sha }}
           restore-keys: |
-            nfdata-${{ matrix.nxf_ver }}-${{ github.sha }}
-            nfdata-${{ matrix.nxf_ver }}-
+            nfdata-test-${{ matrix.nxf_ver }}-${{ github.sha }}
+            nfdata-test-${{ matrix.nxf_ver }}-
 
       - name: Install Nextflow
         run: |
@@ -61,8 +61,7 @@ jobs:
           sudo mv nextflow /usr/local/bin/
 
       - name: Run pipeline with test data
-        run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test,docker -resume
+        run: nextflow run ${GITHUB_WORKSPACE} -profile test,docker -resume
 
   parameters:
     name: Test workflow parameters
@@ -102,10 +101,10 @@ jobs:
           path: |
             work
             .nextflow
-          key: nfdata-${{ matrix.parameters }}-${{ github.sha }}
+          key: nfdata-parameters-${{ matrix.parameters }}-${{ github.sha }}
           restore-keys: |
-            nfdata-${{ matrix.parameters }}-${{ github.sha }}
-            nfdata-${{ matrix.parameters }}-
+            nfdata-parameters-${{ matrix.parameters }}-${{ github.sha }}
+            nfdata-parameters-${{ matrix.parameters }}-
 
       - name: Install Nextflow
         run: |
@@ -113,8 +112,7 @@ jobs:
           sudo mv nextflow /usr/local/bin/
 
       - name: Run pipeline with test amplicon data with various options
-        run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test,docker ${{ matrix.parameters }} -resume
+        run: nextflow run ${GITHUB_WORKSPACE} -profile test,docker ${{ matrix.parameters }} -resume
 
   test_sra:
     name: Test SRA workflow
@@ -154,10 +152,10 @@ jobs:
           path: |
             work
             .nextflow
-          key: nfdata-${{ matrix.parameters }}-${{ github.sha }}
+          key: nfdata-test_sra-${{ matrix.parameters }}-${{ github.sha }}
           restore-keys: |
-            nfdata-${{ matrix.parameters }}-${{ github.sha }}
-            nfdata-${{ matrix.parameters }}-
+            nfdata-test_sra-${{ matrix.parameters }}-${{ github.sha }}
+            nfdata-test_sra-${{ matrix.parameters }}-
 
       - name: Install Nextflow
         run: |
@@ -165,8 +163,7 @@ jobs:
           sudo mv nextflow /usr/local/bin/
 
       - name: Run pipeline with minimal data via SRA ids and various options
-        run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test_sra,docker ${{ matrix.parameters }} -resume
+        run: nextflow run ${GITHUB_WORKSPACE} -profile test_sra,docker ${{ matrix.parameters }} -resume
 
   test_sispa:
     name: Test SISPA workflow
@@ -206,10 +203,10 @@ jobs:
           path: |
             work
             .nextflow
-          key: nfdata-${{ matrix.parameters }}-${{ github.sha }}
+          key: nfdata-test_sispa-${{ matrix.parameters }}-${{ github.sha }}
           restore-keys: |
-            nfdata-${{ matrix.parameters }}-${{ github.sha }}
-            nfdata-${{ matrix.parameters }}-
+            nfdata-test_sispa-${{ matrix.parameters }}-${{ github.sha }}
+            nfdata-test_sispa-${{ matrix.parameters }}-
 
       - name: Install Nextflow
         run: |
@@ -217,8 +214,7 @@ jobs:
           sudo mv nextflow /usr/local/bin/
 
       - name: Run pipeline with minimal SISPA data and various options
-        run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test_sispa,docker ${{ matrix.parameters }} -resume
+        run: nextflow run ${GITHUB_WORKSPACE} -profile test_sispa,docker ${{ matrix.parameters }} -resume
 
   push_dockerhub:
     name: Push new Docker image to Docker Hub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Restore workflow cache
         uses: actions/cache@v2
-        if: ${{ !(github.repository == 'nf-core/viralrecon' && github.head_ref == "master" ) }}
+        if: ${{ !(github.repository == 'nf-core/viralrecon' && github.head_ref == 'master' ) }}
         with:
           path: |
             work
@@ -97,7 +97,7 @@ jobs:
 
       - name: Restore workflow cache
         uses: actions/cache@v2
-        if: ${{ !(github.repository == 'nf-core/viralrecon' && github.head_ref == "master" ) }}
+        if: ${{ !(github.repository == 'nf-core/viralrecon' && github.head_ref == 'master' ) }}
         with:
           path: |
             work
@@ -149,7 +149,7 @@ jobs:
 
       - name: Restore workflow cache
         uses: actions/cache@v2
-        if: ${{ !(github.repository == 'nf-core/viralrecon' && github.head_ref == "master" ) }}
+        if: ${{ !(github.repository == 'nf-core/viralrecon' && github.head_ref == 'master' ) }}
         with:
           path: |
             work
@@ -201,7 +201,7 @@ jobs:
 
       - name: Restore workflow cache
         uses: actions/cache@v2
-        if: ${{ !(github.repository == 'nf-core/viralrecon' && github.head_ref == "master" ) }}
+        if: ${{ !(github.repository == 'nf-core/viralrecon' && github.head_ref == 'master' ) }}
         with:
           path: |
             work

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,18 @@ jobs:
           docker pull nfcore/viralrecon:dev
           docker tag nfcore/viralrecon:dev nfcore/viralrecon:dev
 
+      - name: Restore workflow cache
+        uses: actions/cache@v2
+        if: ${{ !(github.repository == 'nf-core/viralrecon' && github.head_ref == "master" ) }}
+        with:
+          path: |
+            work
+            .nextflow
+          key: nfdata-${{ matrix.nxf_ver }}-${{ github.sha }}
+          restore-keys: |
+            nfdata-${{ matrix.nxf_ver }}-${{ github.sha }}
+            nfdata-${{ matrix.nxf_ver }}-
+
       - name: Install Nextflow
         run: |
           wget -qO- get.nextflow.io | bash
@@ -82,6 +94,18 @@ jobs:
         run: |
           docker pull nfcore/viralrecon:dev
           docker tag nfcore/viralrecon:dev nfcore/viralrecon:dev
+
+      - name: Restore workflow cache
+        uses: actions/cache@v2
+        if: ${{ !(github.repository == 'nf-core/viralrecon' && github.head_ref == "master" ) }}
+        with:
+          path: |
+            work
+            .nextflow
+          key: nfdata-${{ matrix.parameters }}-${{ github.sha }}
+          restore-keys: |
+            nfdata-${{ matrix.parameters }}-${{ github.sha }}
+            nfdata-${{ matrix.parameters }}-
 
       - name: Install Nextflow
         run: |
@@ -123,6 +147,18 @@ jobs:
           docker pull nfcore/viralrecon:dev
           docker tag nfcore/viralrecon:dev nfcore/viralrecon:dev
 
+      - name: Restore workflow cache
+        uses: actions/cache@v2
+        if: ${{ !(github.repository == 'nf-core/viralrecon' && github.head_ref == "master" ) }}
+        with:
+          path: |
+            work
+            .nextflow
+          key: nfdata-${{ matrix.parameters }}-${{ github.sha }}
+          restore-keys: |
+            nfdata-${{ matrix.parameters }}-${{ github.sha }}
+            nfdata-${{ matrix.parameters }}-
+
       - name: Install Nextflow
         run: |
           wget -qO- get.nextflow.io | bash
@@ -162,6 +198,18 @@ jobs:
         run: |
           docker pull nfcore/viralrecon:dev
           docker tag nfcore/viralrecon:dev nfcore/viralrecon:dev
+
+      - name: Restore workflow cache
+        uses: actions/cache@v2
+        if: ${{ !(github.repository == 'nf-core/viralrecon' && github.head_ref == "master" ) }}
+        with:
+          path: |
+            work
+            .nextflow
+          key: nfdata-${{ matrix.parameters }}-${{ github.sha }}
+          restore-keys: |
+            nfdata-${{ matrix.parameters }}-${{ github.sha }}
+            nfdata-${{ matrix.parameters }}-
 
       - name: Install Nextflow
         run: |


### PR DESCRIPTION
Based on code and the suggestion from @rsuchecki, added the GitHub Actions cache action to try to speed up the CI test workflow. Restores the `.nextflow` and `work` directories from previous runs if possible and runs with `-resume`. If a step in the workflow is unchanged, hopefully Nextflow will use the cached results.

Added a check for the pipeline name and branch so that all caching is skipped when merging to `master`.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/viralrecon branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/viralrecon)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README.md` is updated