### PR TITLE
add option input glob

### DIFF
--- a/lib/Checks.groovy
+++ b/lib/Checks.groovy
@@ -63,5 +63,8 @@ class Checks {
             }
         }
     }
-        
+
+    static boolean hasExtension(file, extension) {
+        return file.toString().toLowerCase().endsWith(extension.toLowerCase())
+    }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -13,6 +13,7 @@ params {
   input                        = ''
   platform                     = ''
   protocol                     = ''
+  single_end                   = false
   
   // SRA download options
   public_data_ids              = ''

--- a/subworkflows/local/input_globs_check.nf
+++ b/subworkflows/local/input_globs_check.nf
@@ -1,0 +1,26 @@
+params.options = [:]
+
+workflow INPUT_GLOBS_CHECK {
+    take:
+    input // file  : /path/to/samplesheet.csv
+    platform    // string: sequencing platform. Accepted values: 'illumina', 'nanopore'
+    
+    main:
+
+    input
+        .map { create_fastq_channels(it) }
+        .set { reads }
+
+    emit:
+    reads // channel: [ val(meta), [ reads ] ]
+}
+
+// Function to get list of [ meta, [ fastq_1, fastq_2 ] ]
+def create_fastq_channels(ArrayList tuple) {
+    def meta = [:]
+    meta.id           = tuple[0]
+    meta.single_end   = params.single_end
+
+    array = [ meta, tuple[1] ]
+    return array    
+}


### PR DESCRIPTION
Hi @drpatelh @ewels,

here's a first draft of how adding support for input globs could look like.
I would still add tests and the same option for the nanopore subworkflow, if you find the code for the illumina subworkflow is ok.

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/viralrecon branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/viralrecon)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/viralrecon/tree/master/.github/CONTRIBUTING.md)