### PR TITLE
Default to using --callers bcftools for --protocol metagenomic and --callers ivar for --protocol amplicon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * All software containers are now exclusively obtained from [Biocontainers](https://biocontainers.pro/#/registry)
 * Updated minimum Nextflow version to `v21.04.0` (see [nextflow#572](https://github.com/nextflow-io/nextflow/issues/1964))
 * Default human `--kraken2_db` link has been changed from Zenodo to an AWS S3 bucket for more reliable downloads
+* [BCFtools](http://samtools.github.io/bcftools/bcftools.html) and [iVar](https://github.com/andersen-lab/ivar) will be run by default for Illumina metagenomics and amplicon data, respectively. However, this behaviour can be customised with the `--callers` parameter.
 * Illumina and Nanopore runs containing the same 48 samples sequenced on both platforms have been uploaded to the nf-core AWS account for full-sized tests on release
 * Variant graph processes to call variants relative to the reference genome directly from _de novo_ assemblies have been deprecated and removed
 * Variant calling with Varscan 2 has been deprecated and removed due to [licensing restrictions](https://github.com/dkoboldt/varscan/issues/12)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The pipeline has numerous options to allow you to run only specific aspects of t
     4. Duplicate read marking ([`picard`](https://broadinstitute.github.io/picard/); *optional*)
     5. Alignment-level QC ([`picard`](https://broadinstitute.github.io/picard/), [`SAMtools`](https://sourceforge.net/projects/samtools/files/samtools/))
     6. Genome-wide and amplicon coverage QC plots ([`mosdepth`](https://github.com/brentp/mosdepth/))
-    7. Choice of multiple variant calling and consensus sequence generation routes ([`iVar variants and consensus`](https://github.com/andersen-lab/ivar) *||* [`BCFTools`](http://samtools.github.io/bcftools/bcftools.html), [`BEDTools`](https://github.com/arq5x/bedtools2/))
+    7. Choice of multiple variant calling and consensus sequence generation routes ([`iVar variants and consensus`](https://github.com/andersen-lab/ivar); *default for amplicon data* *||* [`BCFTools`](http://samtools.github.io/bcftools/bcftools.html), [`BEDTools`](https://github.com/arq5x/bedtools2/); *default for metagenomics data*)
         * Variant annotation ([`SnpEff`](http://snpeff.sourceforge.net/SnpEff.html), [`SnpSift`](http://snpeff.sourceforge.net/SnpSift.html))
         * Consensus assessment report ([`QUAST`](http://quast.sourceforge.net/quast))
         * Lineage analysis ([`Pangolin`](https://github.com/cov-lineages/pangolin))

--- a/docs/output.md
+++ b/docs/output.md
@@ -550,7 +550,7 @@ Unless you are using [UMIs](https://emea.illumina.com/science/sequencing-method-
 * `illumina/variants/<CALLER>/snpeff/bcftools_stats/`
   * `*.bcftools_stats.txt`: Statistics and counts obtained from VCF file.
 
-**NB:** The value of `<CALLER>` in the output directory name above is determined by the `--callers` parameter (Default: 'ivar').
+**NB:** The value of `<CALLER>` in the output directory name above is determined by the `--callers` parameter (Default: 'ivar' for '--protocol amplicon' and 'bcftools' for '--protocol metagenomic').
 
 </details>
 
@@ -568,7 +568,7 @@ Unless you are using [UMIs](https://emea.illumina.com/science/sequencing-method-
 * `illumina/variants/<CALLER>/quast/`
   * `report.html`: Results report in HTML format. Also available in various other file formats i.e. `report.pdf`, `report.tex`, `report.tsv` and `report.txt`.
 
-**NB:** The value of `<CALLER>` in the output directory name above is determined by the `--callers` parameter (Default: 'ivar').
+**NB:** The value of `<CALLER>` in the output directory name above is determined by the `--callers` parameter (Default: 'ivar' for '--protocol amplicon' and 'bcftools' for '--protocol metagenomic').
 
 </details>
 
@@ -582,7 +582,7 @@ Unless you are using [UMIs](https://emea.illumina.com/science/sequencing-method-
 * `illumina/variants/<CALLER>/pangolin/`
   * `*.pangolin.csv`: Lineage analysis results from Pangolin.
 
-**NB:** The value of `<CALLER>` in the output directory name above is determined by the `--callers` parameter (Default: 'ivar').
+**NB:** The value of `<CALLER>` in the output directory name above is determined by the `--callers` parameter (Default: 'ivar' for '--protocol amplicon' and 'bcftools' for '--protocol metagenomic').
 
 </details>
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -50,7 +50,7 @@ params {
   skip_kraken2                 = false
 
   // Illumina: Variant calling
-  callers                      = 'ivar'
+  callers                      = null
   min_mapped_reads             = 1000
   ivar_trim_noprimer           = false
   ivar_trim_offset             = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -275,8 +275,7 @@
             "properties": {
                 "callers": {
                     "type": "string",
-                    "default": "ivar",
-                    "description": "Specify which variant calling algorithms you would like to use. Available options are 'ivar' and 'bcftools'.",
+                    "description": "Specify which variant calling algorithms you would like to use. Available options are 'ivar' (default for '--protocol amplicon') and 'bcftools' (default for '--protocol metagenomic').",
                     "fa_icon": "fas fa-phone-volume"
                 },
                 "min_mapped_reads": {

--- a/workflows/illumina.nf
+++ b/workflows/illumina.nf
@@ -30,8 +30,9 @@ ch_dummy_file = file("$projectDir/assets/dummy_file.txt", checkIfExists: true)
 if (params.input)      { ch_input      = file(params.input)      } else { exit 1, 'Input samplesheet file not specified!' }
 if (params.spades_hmm) { ch_spades_hmm = file(params.spades_hmm) } else { ch_spades_hmm = ch_dummy_file                   }
 
-def callers    = params.callers    ? params.callers.split(',').collect{ it.trim().toLowerCase() }    : []
 def assemblers = params.assemblers ? params.assemblers.split(',').collect{ it.trim().toLowerCase() } : []
+def callers    = params.callers    ? params.callers.split(',').collect{ it.trim().toLowerCase() }    : []
+if (!callers)  { callers = params.protocol == 'amplicon' ? ['ivar'] : ['bcftools'] }
 
 /*
 ========================================================================================
@@ -148,7 +149,6 @@ markduplicates_options.args += params.filter_duplicates ?  Utils.joinModuleArgs(
 include { FASTQC_FASTP           } from '../subworkflows/nf-core/fastqc_fastp'           addParams( fastqc_raw_options: modules['illumina_fastqc_raw'], fastqc_trim_options: modules['illumina_fastqc_trim'], fastp_options: fastp_options )
 include { ALIGN_BOWTIE2          } from '../subworkflows/nf-core/align_bowtie2'          addParams( align_options: bowtie2_align_options, samtools_options: modules['illumina_bowtie2_sort_bam']                                           )
 include { MARK_DUPLICATES_PICARD } from '../subworkflows/nf-core/mark_duplicates_picard' addParams( markduplicates_options: markduplicates_options, samtools_options: modules['illumina_picard_markduplicates_sort_bam']                   )
-
 
 /*
 ========================================================================================


### PR DESCRIPTION
This is mainly because iVar doesn't have a clever way of dealing with strand biases that are typical for amplicon data (see https://github.com/andersen-lab/ivar/issues/5). 