### PR TITLE
Bump nextclade and pangolin version

### DIFF
--- a/modules/nf-core/software/nextclade/main.nf
+++ b/modules/nf-core/software/nextclade/main.nf
@@ -11,11 +11,11 @@ process NEXTCLADE {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
-    conda (params.enable_conda ? "bioconda::nextclade_js=0.14.2" : null)
+    conda (params.enable_conda ? "bioconda::nextclade_js=0.14.4" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/nextclade_js:0.14.2--h9ee0642_0"
+        container "https://depot.galaxyproject.org/singularity/nextclade_js:0.14.4--h9ee0642_0"
     } else {
-        container "quay.io/biocontainers/nextclade_js:0.14.2--h9ee0642_0"
+        container "quay.io/biocontainers/nextclade_js:0.14.4--h9ee0642_0"
     }
 
     input:

--- a/modules/nf-core/software/pangolin/main.nf
+++ b/modules/nf-core/software/pangolin/main.nf
@@ -11,11 +11,11 @@ process PANGOLIN {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
-    conda (params.enable_conda ? 'bioconda::pangolin=2.4.2' : null)
+    conda (params.enable_conda ? 'bioconda::pangolin=3.0.5' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-        container 'https://depot.galaxyproject.org/singularity/pangolin:2.4.2--pyhdfd78af_0'
+        container 'https://depot.galaxyproject.org/singularity/pangolin:3.0.5--pyhdfd78af_0'
     } else {
-        container 'quay.io/biocontainers/pangolin:2.4.2--pyhdfd78af_0'
+        container 'quay.io/biocontainers/pangolin:3.0.5--pyhdfd78af_0'
     }
 
     input:


### PR DESCRIPTION
Update Nextclade to version 0.14.4 and Pangolin to version 3.0.5 (commit message on 05e0b53 shows the old version instead of the updated version... my mistake)
## PR checklist 

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/viralrecon/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/viralrecon _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
