### PR TITLE
Fixed make_bed_mask for insertions with low coverage

### DIFF
--- a/bin/make_bed_mask.py
+++ b/bin/make_bed_mask.py
@@ -19,23 +19,6 @@ def parse_args(args=None):
 
 def find_indels_vcf(vcf_in):
     encoding = "utf-8"
-    indels_pos_len = {}
-    with gzip.open(vcf_in, "r") as f:
-        for line in f:
-            if "#" not in str(line, encoding):
-                line = re.split("\t", str(line, encoding))
-                var_pos = line[1]
-                ref = line[3]
-                alt = line[4]
-                if len(alt) > len(ref):
-                    indels_pos_len[var_pos] = len(alt)
-                elif len(ref) > len(alt):
-                    indels_pos_len[var_pos] = len(ref)
-    return indels_pos_len
-
-
-def find_dels_vcf(vcf_in):
-    encoding = "utf-8"
     dels_pos_len = {}
     with gzip.open(vcf_in, "r") as f:
         for line in f:
@@ -44,7 +27,7 @@ def find_dels_vcf(vcf_in):
                 var_pos = line[1]
                 ref = line[3]
                 alt = line[4]
-                if len(ref) > len(alt):
+                if len(ref) != len(alt):
                     dels_pos_len[var_pos] = len(ref)
     return dels_pos_len
 
@@ -80,7 +63,7 @@ def make_bed_mask(bed_in, bed_out, indels_pos_len):
 
 def main(args=None):
     args = parse_args(args)
-    indels_pos_len = find_dels_vcf(args.VCF_IN)
+    indels_pos_len = find_indels_vcf(args.VCF_IN)
     make_bed_mask(args.BED_IN, args.BED_OUT, indels_pos_len)
 
 

--- a/bin/make_bed_mask.py
+++ b/bin/make_bed_mask.py
@@ -19,7 +19,7 @@ def parse_args(args=None):
 
 def find_indels_vcf(vcf_in):
     encoding = "utf-8"
-    dels_pos_len = {}
+    indels_pos_len = {}
     with gzip.open(vcf_in, "r") as f:
         for line in f:
             if "#" not in str(line, encoding):
@@ -28,8 +28,8 @@ def find_indels_vcf(vcf_in):
                 ref = line[3]
                 alt = line[4]
                 if len(ref) != len(alt):
-                    dels_pos_len[var_pos] = len(ref)
-    return dels_pos_len
+                    indels_pos_len[var_pos] = len(ref)
+    return indels_pos_len
 
 
 def make_bed_mask(bed_in, bed_out, indels_pos_len):


### PR DESCRIPTION
make_bed_mask.py was not working when --skip_fastp was calling for low coverage insertions. This fix will include insertions in the make_bed_mask.py script.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/viralrecon/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/viralrecon _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [X] Usage Documentation in `docs/usage.md` is updated.
- [X] Output Documentation in `docs/output.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [X] `README.md` is updated (including new tool citations and authors/contributors).
