### PR TITLE
Add long format table to ONT output

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The SRA download functionality has been removed from the pipeline (`>=2.1`) and 
         * Consensus assessment report ([`QUAST`](http://quast.sourceforge.net/quast))
         * Lineage analysis ([`Pangolin`](https://github.com/cov-lineages/pangolin))
         * Clade assignment, mutation calling and sequence quality checks ([`Nextclade`](https://github.com/nextstrain/nextclade))
-    9. Create variants long format table collating per-sample information for individual variants ([`BCFTools`](http://samtools.github.io/bcftools/bcftools.html)), functional effect prediction ([`SnpSift`](http://snpeff.sourceforge.net/SnpSift.html)) and lineage analysis ([`Pangolin`](https://github.com/cov-lineages/pangolin)).
+    9. Create variants long format table collating per-sample information for individual variants ([`BCFTools`](http://samtools.github.io/bcftools/bcftools.html)), functional effect prediction ([`SnpSift`](http://snpeff.sourceforge.net/SnpSift.html)) and lineage analysis ([`Pangolin`](https://github.com/cov-lineages/pangolin))
 6. _De novo_ assembly
     1. Primer trimming ([`Cutadapt`](https://cutadapt.readthedocs.io/en/stable/guide.html); *amplicon data only*)
     2. Choice of multiple assembly tools ([`SPAdes`](http://cab.spbu.ru/software/spades/) *||* [`Unicycler`](https://github.com/rrwick/Unicycler) *||* [`minia`](https://github.com/GATB/minia))
@@ -73,6 +73,7 @@ The SRA download functionality has been removed from the pipeline (`>=2.1`) and 
     * Lineage analysis ([`Pangolin`](https://github.com/cov-lineages/pangolin))
     * Clade assignment, mutation calling and sequence quality checks ([`Nextclade`](https://github.com/nextstrain/nextclade))
     * Individual variant screenshots with annotation tracks ([`ASCIIGenome`](https://asciigenome.readthedocs.io/en/latest/))
+    * Create variants long format table collating per-sample information for individual variants ([`BCFTools`](http://samtools.github.io/bcftools/bcftools.html)), functional effect prediction ([`SnpSift`](http://snpeff.sourceforge.net/SnpSift.html)) and lineage analysis ([`Pangolin`](https://github.com/cov-lineages/pangolin))
 8. Present QC, visualisation and custom reporting for sequencing, raw reads, alignment and variant calling results ([`MultiQC`](http://multiqc.info/))
 
 ## Quick Start

--- a/bin/make_variants_long_table.py
+++ b/bin/make_variants_long_table.py
@@ -25,7 +25,7 @@ def parser_args(args=None):
     parser.add_argument("-bd", "--bcftools_query_dir"  , type=str, default="./bcftools_query"       , help="Directory containing output of BCFTools query for each sample (default: './bcftools_query').")
     parser.add_argument("-sd", "--snpsift_dir"         , type=str, default="./snpsift"              , help="Directory containing output of SnpSift for each sample (default: './snpsift').")
     parser.add_argument("-pd", "--pangolin_dir"        , type=str, default="./pangolin"             , help="Directory containing output of Pangolin for each sample (default: './pangolin').")
-    parser.add_argument("-bs", "--bcftools_file_suffix", type=str, default=".table"                 , help="Suffix to trim off BCFTools query file name to obtain sample name (default: '.table').")
+    parser.add_argument("-bs", "--bcftools_file_suffix", type=str, default=".bcftools_query.txt"    , help="Suffix to trim off BCFTools query file name to obtain sample name (default: '.bcftools_query.txt').")
     parser.add_argument("-ss", "--snpsift_file_suffix" , type=str, default=".snpsift.txt"           , help="Suffix to trim off SnpSift file name to obtain sample name (default: '.snpsift.txt').")
     parser.add_argument("-ps", "--pangolin_file_suffix", type=str, default=".pangolin.csv"          , help="Suffix to trim off Pangolin file name to obtain sample name (default: '.pangolin.csv').")
     parser.add_argument("-of", "--output_file"         , type=str, default="variants_long_table.csv", help="Full path to output file (default: 'variants_long_table.csv').")

--- a/bin/make_variants_long_table.py
+++ b/bin/make_variants_long_table.py
@@ -45,6 +45,7 @@ def make_dir(path):
 def get_file_dict(file_dir, file_suffix):
     files = glob.glob(os.path.join(file_dir, f'*{file_suffix}'))
     samples = [os.path.basename(x).rstrip(f'{file_suffix}') for x in files]
+
     return dict(zip(samples, files))
 
 
@@ -61,6 +62,7 @@ def three_letter_aa_to_one(hgvs_three):
     for key in aa_dict:
         if key in hgvs_one:
             hgvs_one = hgvs_one.replace(str(key),str(aa_dict[key]))
+
     return hgvs_one
 
 
@@ -74,9 +76,12 @@ def ivar_bcftools_query_to_table(bcftools_query_file):
     old_colnames = list(table.columns)
     new_colnames = [x.split(']')[-1].split(':')[-1] for x in old_colnames]
     table.rename(columns=dict(zip(old_colnames, new_colnames)), inplace=True)
-    table[["ALT_DP", "DP"]] = table[["ALT_DP", "DP"]].apply(pd.to_numeric)
-    table['AF'] = table['ALT_DP'] / table['DP']
-    table['AF'] = table['AF'].round(2)
+
+    if not table.empty:
+        table[["ALT_DP", "DP"]] = table[["ALT_DP", "DP"]].apply(pd.to_numeric)
+        table['AF'] = table['ALT_DP'] / table['DP']
+        table['AF'] = table['AF'].round(2)
+
     return table
 
 
@@ -90,11 +95,41 @@ def bcftools_bcftools_query_to_table(bcftools_query_file):
     old_colnames = list(table.columns)
     new_colnames = [x.split(']')[-1].split(':')[-1] for x in old_colnames]
     table.rename(columns=dict(zip(old_colnames, new_colnames)), inplace=True)
-    table[['REF_DP','ALT_DP']] = table['AD'].str.split(',', expand=True)
-    table[["ALT_DP", "DP"]] = table[["ALT_DP", "DP"]].apply(pd.to_numeric)
-    table['AF'] = table['ALT_DP'] / table['DP']
-    table['AF'] = table['AF'].round(2)
-    table.drop('AD', axis=1, inplace=True)
+
+    if not table.empty:
+        table[['REF_DP','ALT_DP']] = table['AD'].str.split(',', expand=True)
+        table[["ALT_DP", "DP"]] = table[["ALT_DP", "DP"]].apply(pd.to_numeric)
+        table['AF'] = table['ALT_DP'] / table['DP']
+        table['AF'] = table['AF'].round(2)
+        table.drop('AD', axis=1, inplace=True)
+
+    return table
+
+
+## Returns a pandas dataframe in the format:
+    #         CHROM   POS REF ALT FILTER  DP  REF_DP  ALT_DP    AF
+    # 0  MN908947.3   241   C   T   PASS  30       1      29  0.97
+    # 1  MN908947.3  1163   A   T   PASS  28       0      28  1.00
+def nanopolish_bcftools_query_to_table(bcftools_query_file):
+    table = pd.read_table(bcftools_query_file, header='infer')
+    table = table.dropna(how='all', axis=1)
+    old_colnames = list(table.columns)
+    new_colnames = [x.split(']')[-1].split(':')[-1] for x in old_colnames]
+    table.rename(columns=dict(zip(old_colnames, new_colnames)), inplace=True)
+
+    ## Split out ref/alt depths from StrandSupport column
+    if not table.empty:
+        table_cp = table.copy()
+        table_cp[['FORW_REF_DP','REV_REF_DP', 'FORW_ALT_DP','REV_ALT_DP']] = table_cp['StrandSupport'].str.split(',', expand=True)
+        table_cp[['FORW_REF_DP','REV_REF_DP', 'FORW_ALT_DP','REV_ALT_DP']] = table_cp[['FORW_REF_DP','REV_REF_DP', 'FORW_ALT_DP','REV_ALT_DP']].apply(pd.to_numeric)
+
+        table['DP'] = table_cp[['FORW_REF_DP','REV_REF_DP', 'FORW_ALT_DP','REV_ALT_DP']].sum(axis=1)
+        table['REF_DP'] = table_cp[['FORW_REF_DP','REV_REF_DP']].sum(axis=1)
+        table['ALT_DP'] = table_cp[['FORW_ALT_DP','REV_ALT_DP']].sum(axis=1)
+        table['AF'] = table['ALT_DP'] / table['DP']
+        table['AF'] = table['AF'].round(2)
+        table.drop('StrandSupport', axis=1, inplace=True)
+
     return table
 
 
@@ -122,6 +157,7 @@ def snpsift_to_table(snpsift_file):
         hgvs_p = three_letter_aa_to_one(str(item))
         aa.append(hgvs_p)
     table["HGVS_P_1LETTER"] = pd.Series(aa)
+
     return table
 
 
@@ -163,24 +199,29 @@ def main(args=None):
             bcftools_table = ivar_bcftools_query_to_table(bcftools_files[sample])
         elif args.variant_caller == 'bcftools':
             bcftools_table = bcftools_bcftools_query_to_table(bcftools_files[sample])
+        elif args.variant_caller == 'nanopolish':
+            bcftools_table = nanopolish_bcftools_query_to_table(bcftools_files[sample])
 
-        ## Read in SnpSift file
-        snpsift_table = snpsift_to_table(snpsift_files[sample])
+        if not bcftools_table.empty:
 
-        merged_table = pd.DataFrame(data = bcftools_table)
-        merged_table.insert(0,'SAMPLE', sample)
-        merged_table = pd.merge(merged_table, snpsift_table, how='outer')
-        merged_table['CALLER'] = args.variant_caller
+            ## Read in SnpSift file
+            snpsift_table = snpsift_to_table(snpsift_files[sample])
 
-        ## Read in Pangolin lineage file
-        if pangolin_files:
-            merged_table['LINEAGE'] = get_pangolin_lineage(pangolin_files[sample])
+            merged_table = pd.DataFrame(data = bcftools_table)
+            merged_table.insert(0,'SAMPLE', sample)
+            merged_table = pd.merge(merged_table, snpsift_table, how='outer')
+            merged_table['CALLER'] = args.variant_caller
 
-        sample_tables.append(merged_table)
+            ## Read in Pangolin lineage file
+            if pangolin_files:
+                merged_table['LINEAGE'] = get_pangolin_lineage(pangolin_files[sample])
+
+            sample_tables.append(merged_table)
 
     ## Merge table across samples
-    merged_tables = pd.concat(sample_tables)
-    merged_tables.to_csv(args.output_file, index=False, encoding='utf-8-sig')
+    if sample_tables:
+        merged_tables = pd.concat(sample_tables)
+        merged_tables.to_csv(args.output_file, index=False, encoding='utf-8-sig')
 
 
 if __name__ == '__main__':

--- a/conf/modules_illumina.config
+++ b/conf/modules_illumina.config
@@ -532,6 +532,7 @@ if (!params.skip_variants) {
                         variant_caller == 'ivar'     ? "-H -f '%CHROM\\t%POS\\t%REF\\t%ALT\\t%FILTER\\t[%DP\\t]\\t[%REF_DP\\t]\\t[%ALT_DP\\t]\\n'" : '',
                         variant_caller == 'bcftools' ? "-H -f '%CHROM\\t%POS\\t%REF\\t%ALT\\t%FILTER\\t[%DP\\t]\\t[%AD\\t]\\n'" : '',
                     ].join(' ').trim()
+                    ext.prefix = { "${meta.id}.bcftools_query" }
                     publishDir = [
                         path: { "${params.outdir}/variants/${variant_caller}" },
                         enabled: false

--- a/conf/modules_nanopore.config
+++ b/conf/modules_nanopore.config
@@ -323,11 +323,11 @@ if (!params.skip_snpeff) {
     if (!params.skip_variants_long_table) {
         process {
             withName: 'BCFTOOLS_QUERY' {
-                cache = false
                 ext.args = [
                     params.artic_minion_caller == 'nanopolish' ? "-H -f '%CHROM\\t%POS\\t%REF\\t%ALT\\t%FILTER\\t%StrandSupport\\n'" : '',
                     params.artic_minion_caller == 'medaka'     ? "-H -f '%CHROM\\t%POS\\t%REF\\t%ALT\\t%FILTER\\t%DP\\t%AC\\n'" : ''
                 ].join(' ').trim()
+                ext.prefix = { "${meta.id}.bcftools_query" }
                 publishDir = [
                     path: { "${params.outdir}/${params.artic_minion_caller}" },
                     enabled: false

--- a/conf/modules_nanopore.config
+++ b/conf/modules_nanopore.config
@@ -319,6 +319,30 @@ if (!params.skip_snpeff) {
             ]
         }
     }
+
+    if (!params.skip_variants_long_table) {
+        process {
+            withName: 'BCFTOOLS_QUERY' {
+                ext.args = [
+                    params.artic_minion_caller == 'nanopolish' ? "-H -f '%CHROM\\t%POS\\t%REF\\t%ALT\\t%FILTER\\t[%DP\\t]\\t[%AD\\t]\\n'" : '',
+                    params.artic_minion_caller == 'medaka'     ? "-H -f '%CHROM\\t%POS\\t%REF\\t%ALT\\t%FILTER\\t[%DP\\t]\\t[%AD\\t]\\n'" : ''
+                ].join(' ').trim()
+                publishDir = [
+                    path: { "${params.outdir}/${params.artic_minion_caller}" },
+                    enabled: false
+                ]
+            }
+
+            withName: 'MAKE_VARIANTS_LONG_TABLE' {
+                ext.args = "--variant_caller ${params.artic_minion_caller}"
+                publishDir = [
+                    path: { "${params.outdir}/${params.artic_minion_caller}" },
+                    mode: 'copy',
+                    saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+                ]
+            }
+        }
+    }
 }
 
 if (!params.skip_asciigenome) {

--- a/conf/modules_nanopore.config
+++ b/conf/modules_nanopore.config
@@ -323,9 +323,10 @@ if (!params.skip_snpeff) {
     if (!params.skip_variants_long_table) {
         process {
             withName: 'BCFTOOLS_QUERY' {
+                cache = false
                 ext.args = [
-                    params.artic_minion_caller == 'nanopolish' ? "-H -f '%CHROM\\t%POS\\t%REF\\t%ALT\\t%FILTER\\t[%DP\\t]\\t[%AD\\t]\\n'" : '',
-                    params.artic_minion_caller == 'medaka'     ? "-H -f '%CHROM\\t%POS\\t%REF\\t%ALT\\t%FILTER\\t[%DP\\t]\\t[%AD\\t]\\n'" : ''
+                    params.artic_minion_caller == 'nanopolish' ? "-H -f '%CHROM\\t%POS\\t%REF\\t%ALT\\t%FILTER\\t%StrandSupport\\n'" : '',
+                    params.artic_minion_caller == 'medaka'     ? "-H -f '%CHROM\\t%POS\\t%REF\\t%ALT\\t%FILTER\\t%DP\\t%AC\\n'" : ''
                 ].join(' ').trim()
                 publishDir = [
                     path: { "${params.outdir}/${params.artic_minion_caller}" },

--- a/docs/output.md
+++ b/docs/output.md
@@ -22,6 +22,7 @@ The directories listed below will be created in the results directory after the 
     * [Pangolin](#nanopore-pangolin) - Lineage analysis
     * [Nextclade](#nanopore-nextclade) - Clade assignment, mutation calling and sequence quality checks
     * [ASCIIGenome](#nanopore-asciigenome) - Individual variant screenshots with annotation tracks
+    * [Variants long table](#nanopore-variants-long-table) - Collate per-sample information for individual variants, functional effect prediction and lineage analysis
 * [Workflow reporting](#nanopore-workflow-reporting)
     * [MultiQC](#nanopore-multiqc) - Present QC, visualisation and custom reporting for sequencing, raw reads, alignment and variant calling results
 
@@ -256,6 +257,30 @@ Phylogenetic Assignment of Named Global Outbreak LINeages ([Pangolin](https://gi
 As described in the documentation, [ASCIIGenome](https://asciigenome.readthedocs.io/en/latest/) is a command-line genome browser that can be run from a terminal window and is solely based on ASCII characters. The closest program to ASCIIGenome is probably [samtools tview](http://www.htslib.org/doc/samtools-tview.html) but ASCIIGenome offers much more flexibility, similar to popular GUI viewers like the [IGV](https://software.broadinstitute.org/software/igv/) browser. We are using the batch processing mode of ASCIIGenome in this pipeline to generate individual screenshots for all of the variant sites reported for each sample in the VCF files. This is incredibly useful to be able to quickly QC the variants called by the pipeline without having to tediously load all of the relevant tracks into a conventional genome browser. Where possible, the BAM read alignments, VCF variant file, primer BED file and GFF annotation track will be represented in the screenshot for contextual purposes. The screenshot below shows a SNP called relative to the MN908947.3 SARS-CoV-2 reference genome that overlaps the ORF7a protein and the nCoV-2019_91_LEFT primer from the ARIC v3 protocol.
 
 <p align="center"><img src="images/asciigenome_screenshot.png" alt="ASCIIGenome screenshot"></p>
+
+### Nanopore: Variants long table
+
+<details markdown="1">
+<summary>Output files</summary>
+
+* `<CALLER>/`
+    * `variants_long_table.csv`: Long format table collating per-sample information for individual variants, functional effect prediction and lineage analysis.
+
+**NB:** The value of `<CALLER>` in the output directory name above is determined by the `--artic_minion_caller` parameter (Default: 'nanopolish').
+
+</details>
+
+Create variants long format table collating per-sample information for individual variants ([`BCFTools`](http://samtools.github.io/bcftools/bcftools.html)), functional effect prediction ([`SnpSift`](http://snpeff.sourceforge.net/SnpSift.html)) and lineage analysis ([`Pangolin`](https://github.com/cov-lineages/pangolin)).
+
+The more pertinent variant information is summarised in this table to make it easier for researchers to assess the impact of variants found amongst the sequenced sample(s). An example of the fields included in the table are shown below:
+
+```bash
+SAMPLE,CHROM,POS,REF,ALT,FILTER,DP,REF_DP,ALT_DP,AF,GENE,EFFECT,HGVS_C,HGVS_P,HGVS_P_1LETTER,CALLER,LINEAGE
+SAMPLE1_PE,MN908947.3,241,C,T,PASS,489,4,483,0.99,orf1ab,upstream_gene_variant,c.-25C>T,.,.,ivar,B.1
+SAMPLE1_PE,MN908947.3,1875,C,T,PASS,92,62,29,0.32,orf1ab,missense_variant,c.1610C>T,p.Ala537Val,p.A537V,ivar,B.1
+SAMPLE1_PE,MN908947.3,3037,C,T,PASS,213,0,213,1.0,orf1ab,synonymous_variant,c.2772C>T,p.Phe924Phe,p.F924F,ivar,B.1
+SAMPLE1_PE,MN908947.3,11719,G,A,PASS,195,9,186,0.95,orf1ab,synonymous_variant,c.11454G>A,p.Gln3818Gln,p.Q3818Q,ivar,B.1
+```
 
 ## Nanopore: Workflow reporting
 

--- a/modules.json
+++ b/modules.json
@@ -28,7 +28,7 @@
                 "git_sha": "e751e5040af57e1b4e06ed4e0f3efe6de25c1683"
             },
             "bcftools/query": {
-                "git_sha": "e751e5040af57e1b4e06ed4e0f3efe6de25c1683"
+                "git_sha": "aa2eca69975dc3b53b0c2fbffcaf70b0112c08d8"
             },
             "bcftools/stats": {
                 "git_sha": "e751e5040af57e1b4e06ed4e0f3efe6de25c1683"
@@ -94,13 +94,13 @@
                 "git_sha": "e751e5040af57e1b4e06ed4e0f3efe6de25c1683"
             },
             "nextclade/datasetget": {
-                "git_sha": "d70526c80665d412404e50708998b19cfb0dee7d"
+                "git_sha": "aa2eca69975dc3b53b0c2fbffcaf70b0112c08d8"
             },
             "nextclade/run": {
-                "git_sha": "d70526c80665d412404e50708998b19cfb0dee7d"
+                "git_sha": "aa2eca69975dc3b53b0c2fbffcaf70b0112c08d8"
             },
             "pangolin": {
-                "git_sha": "e751e5040af57e1b4e06ed4e0f3efe6de25c1683"
+                "git_sha": "aa2eca69975dc3b53b0c2fbffcaf70b0112c08d8"
             },
             "picard/collectmultiplemetrics": {
                 "git_sha": "e751e5040af57e1b4e06ed4e0f3efe6de25c1683"

--- a/modules/nf-core/modules/bcftools/query/main.nf
+++ b/modules/nf-core/modules/bcftools/query/main.nf
@@ -8,30 +8,29 @@ process BCFTOOLS_QUERY {
         'quay.io/biocontainers/bcftools:1.14--h88f3f91_0' }"
 
     input:
-    tuple val(meta), path(vcf), path(index)
-    path(regions)
-    path(targets)
-    path(samples)
+    tuple val(meta), path(vcf), path(tbi)
+    path regions
+    path targets
+    path samples
 
     output:
-    tuple val(meta), path("*.table") , emit: vcf
+    tuple val(meta), path("*.txt"), emit: txt
     path "versions.yml"           , emit: versions
 
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def regions_file  = regions ? "--regions-file ${regions}" : ""
+    def regions_file = regions ? "--regions-file ${regions}" : ""
     def targets_file = targets ? "--targets-file ${targets}" : ""
     def samples_file =  samples ? "--samples-file ${samples}" : ""
-
     """
     bcftools query \\
-        --output ${prefix}.table \\
-        ${regions_file} \\
-        ${targets_file} \\
-        ${samples_file} \\
+        --output ${prefix}.txt \\
+        $regions_file \\
+        $targets_file \\
+        $samples_file \\
         $args \\
-        ${vcf}
+        $vcf
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/modules/bcftools/query/meta.yml
+++ b/modules/nf-core/modules/bcftools/query/meta.yml
@@ -23,22 +23,20 @@ input:
         type: file
         description: |
           The vcf file to be qeuried.
-          e.g. 'file.vcf'
-    - index:
+        pattern: "*.{vcf.gz, vcf}"
+    - tbi:
         type: file
         description: |
           The tab index for the VCF file to be inspected.
-          e.g. 'file.tbi'
+        pattern: "*.tbi"
     - regions:
         type: file
         description: |
           Optionally, restrict the operation to regions listed in this file.
-          e.g. 'file.vcf'
     - targets:
         type: file
         description: |
           Optionally, restrict the operation to regions listed in this file (doesn't rely upon index files)
-          e.g. 'file.vcf'
     - samples:
         type: file
         description: |
@@ -50,13 +48,14 @@ output:
         description: |
           Groovy Map containing sample information
           e.g. [ id:'test', single_end:false ]
-    - vcf:
+    - txt:
         type: file
-        description: VCF query output file
-        pattern: "*.{vcf.gz}"
+        description: BCFTools query output file
+        pattern: "*.txt"
     - versions:
         type: file
         description: File containing software versions
         pattern: "versions.yml"
 authors:
   - "@abhi18av"
+  - "@drpatelh"

--- a/modules/nf-core/modules/nextclade/datasetget/main.nf
+++ b/modules/nf-core/modules/nextclade/datasetget/main.nf
@@ -2,10 +2,10 @@ process NEXTCLADE_DATASETGET {
     tag "$dataset"
     label 'process_low'
 
-    conda (params.enable_conda ? "bioconda::nextclade=1.10.1" : null)
+    conda (params.enable_conda ? "bioconda::nextclade=1.10.2" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/nextclade:1.10.1--h9ee0642_0' :
-        'quay.io/biocontainers/nextclade:1.10.1--h9ee0642_0' }"
+        'https://depot.galaxyproject.org/singularity/nextclade:1.10.2--h9ee0642_0' :
+        'quay.io/biocontainers/nextclade:1.10.2--h9ee0642_0' }"
 
     input:
     val dataset

--- a/modules/nf-core/modules/nextclade/run/main.nf
+++ b/modules/nf-core/modules/nextclade/run/main.nf
@@ -2,10 +2,10 @@ process NEXTCLADE_RUN {
     tag "$meta.id"
     label 'process_low'
 
-    conda (params.enable_conda ? "bioconda::nextclade=1.10.1" : null)
+    conda (params.enable_conda ? "bioconda::nextclade=1.10.2" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/nextclade:1.10.1--h9ee0642_0' :
-        'quay.io/biocontainers/nextclade:1.10.1--h9ee0642_0' }"
+        'https://depot.galaxyproject.org/singularity/nextclade:1.10.2--h9ee0642_0' :
+        'quay.io/biocontainers/nextclade:1.10.2--h9ee0642_0' }"
 
     input:
     tuple val(meta), path(fasta)

--- a/modules/nf-core/modules/pangolin/main.nf
+++ b/modules/nf-core/modules/pangolin/main.nf
@@ -2,10 +2,10 @@ process PANGOLIN {
     tag "$meta.id"
     label 'process_medium'
 
-    conda (params.enable_conda ? 'bioconda::pangolin=3.1.17' : null)
+    conda (params.enable_conda ? 'bioconda::pangolin=3.1.19' : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/pangolin:3.1.17--pyhdfd78af_0' :
-        'quay.io/biocontainers/pangolin:3.1.17--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/pangolin:3.1.19--pyhdfd78af_0' :
+        'quay.io/biocontainers/pangolin:3.1.19--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(fasta)

--- a/subworkflows/local/variants_long_table.nf
+++ b/subworkflows/local/variants_long_table.nf
@@ -22,20 +22,18 @@ workflow VARIANTS_LONG_TABLE {
         [],
         []
     )
-    ch_query_table = BCFTOOLS_QUERY.out.vcf
-    ch_versions    = ch_versions.mix(BCFTOOLS_QUERY.out.versions.first())
+    ch_versions = ch_versions.mix(BCFTOOLS_QUERY.out.versions.first())
 
     MAKE_VARIANTS_LONG_TABLE (
-        ch_query_table.collect{it[1]},
+        BCFTOOLS_QUERY.out.txt.collect{it[1]},
         snpsift.collect{it[1]}.ifEmpty([]),
         pangolin.collect{it[1]}.ifEmpty([])
     )
-    ch_long_table = MAKE_VARIANTS_LONG_TABLE.out.csv
-    ch_versions   = ch_versions.mix(MAKE_VARIANTS_LONG_TABLE.out.versions)
+    ch_versions = ch_versions.mix(MAKE_VARIANTS_LONG_TABLE.out.versions)
 
     emit:
-    query_table = ch_query_table // channel: [ val(meta), [ txt ] ]
-    long_table  = ch_long_table  // channel: [ val(meta), [ csv ] ]
+    query_table = BCFTOOLS_QUERY.out.txt           // channel: [ val(meta), [ txt ] ]
+    long_table  = MAKE_VARIANTS_LONG_TABLE.out.csv // channel: [ val(meta), [ csv ] ]
 
     versions    = ch_versions    // channel: [ versions.yml ]
 }

--- a/workflows/nanopore.nf
+++ b/workflows/nanopore.nf
@@ -63,9 +63,10 @@ include { MULTIQC_TSV_FROM_LIST as MULTIQC_TSV_NEXTCLADE          } from '../mod
 //
 // SUBWORKFLOW: Consisting of a mix of local and nf-core/modules
 //
-include { INPUT_CHECK    } from '../subworkflows/local/input_check'
-include { PREPARE_GENOME } from '../subworkflows/local/prepare_genome_nanopore'
-include { SNPEFF_SNPSIFT } from '../subworkflows/local/snpeff_snpsift'
+include { INPUT_CHECK         } from '../subworkflows/local/input_check'
+include { PREPARE_GENOME      } from '../subworkflows/local/prepare_genome_nanopore'
+include { SNPEFF_SNPSIFT      } from '../subworkflows/local/snpeff_snpsift'
+include { VARIANTS_LONG_TABLE } from '../subworkflows/local/variants_long_table'
 
 /*
 ========================================================================================
@@ -480,6 +481,19 @@ workflow NANOPORE {
             params.asciigenome_read_depth
         )
         ch_versions = ch_versions.mix(ASCIIGENOME.out.versions.first().ifEmpty(null))
+    }
+
+    //
+    // SUBWORKFLOW: Create variants long table report
+    //
+    if (!params.skip_variants_long_table && params.gff && !params.skip_snpeff) {
+        VARIANTS_LONG_TABLE (
+            VCFLIB_VCFUNIQ.out.vcf,
+            TABIX_TABIX.out.tbi,
+            ch_snpsift_txt,
+            ch_pangolin_multiqc
+        )
+        ch_versions = ch_versions.mix(VARIANTS_LONG_TABLE.out.versions)
     }
 
     //


### PR DESCRIPTION
Complementary to https://github.com/nf-core/viralrecon/pull/266 https://github.com/nf-core/viralrecon/pull/268

## TODO

- [x] Update BCFTools Query args in `modules_nanopore.config`
- [x] Update long table Python script to parse BCFTools Query file for `--artic_minion_caller nanopolish` and `--artic_minion_caller medaka`
- [x] Double-check format of final output table for `--artic_minion_caller nanopolish` and `--artic_minion_caller medaka` is the same as with Illumina.
