### PR TITLE
update conda recipe for artic minion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[nf-core/rnaseq#764](https://github.com/nf-core/rnaseq/issues/764)] - Test fails when using GCP due to missing tools in the basic biocontainer
 - Updated pipeline template to [nf-core/tools 2.4.1](https://github.com/nf-core/tools/releases/tag/2.4.1)
 - Re-factor code of `ivar_variants_to_vcf` script.
+- Add `muscle=3.8` to `artic minion` conda environment, which fixes a [known bug](https://github.com/artic-network/fieldbioinformatics/issues/105) in the Conda recipe for Artic 1.2.1.
 
 ### Parameters
 

--- a/modules/nf-core/modules/artic/minion/main.nf
+++ b/modules/nf-core/modules/artic/minion/main.nf
@@ -2,7 +2,7 @@ process ARTIC_MINION {
     tag "$meta.id"
     label 'process_high'
 
-    conda (params.enable_conda ? "bioconda::artic=1.2.1" : null)
+    conda (params.enable_conda ? "bioconda::artic=1.2.1 bioconda::muscle=3.8" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/artic:1.2.1--py_0' :
         'quay.io/biocontainers/artic:1.2.1--py_0' }"


### PR DESCRIPTION
<!--
# nf-core/viralrecon pull request

Many thanks for contributing to nf-core/viralrecon!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/viralrecon/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/viralrecon/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/viralrecon _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

---- 

This pull request fixes a [known bug](https://github.com/artic-network/fieldbioinformatics/issues/105) in the conda recipe for `artic=1.2.1`, which makes the pipeline fail. This can be fixed by ensuring `muscle` version 3.8 is installed. 

- I have successfully ran the tests using `nextflow run . -profile test_full_nanopore,conda --outdir results`. 
- I have also informally tested this on a [workshop that introduces your pipeline](https://cambiotraining.github.io/sars-cov-2-genomics/), which fixed the problem for us (we didn't have _Singularity_ on our training environment, that's why we resorted to _Conda_ and found the bug). 
- I have added a note about the fix to `CHANGELOG.md`.

PS - Thank you for all the work in these core pipelines!