### PR TITLE
Fixed problem with no annotation and duplicated lines in ivar_variants_to_vcf_script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Enhancements & fixes
 
--  [[#321](https://github.com/nf-core/viralrecon/issues/321)] `ivar_variants_to_vcf` script: Duplicated positions in tsv file due to overlapping annotations.
--  [[#317](https://github.com/nf-core/viralrecon/issues/317)] `ivar_variants_to_vcf`: Ignore lines without annotation in ivar tsv file
+- [[#321](https://github.com/nf-core/viralrecon/issues/321)] `ivar_variants_to_vcf` script: Duplicated positions in tsv file due to overlapping annotations.
+- [[#317](https://github.com/nf-core/viralrecon/issues/317)] `ivar_variants_to_vcf`: Ignore lines without annotation in ivar tsv file
 
 ### Parameters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Enhancements & fixes
 
+-  [[#321](https://github.com/nf-core/viralrecon/issues/321)] `ivar_variants_to_vcf` script: Duplicated positions in tsv file due to overlapping annotations.
+-  [[#317](https://github.com/nf-core/viralrecon/issues/317)] `ivar_variants_to_vcf`: Ignore lines without annotation in ivar tsv file
+
 ### Parameters
 
 ## [[2.5](https://github.com/nf-core/viralrecon/releases/tag/2.5)] - 2022-07-13

--- a/bin/ivar_variants_to_vcf.py
+++ b/bin/ivar_variants_to_vcf.py
@@ -316,8 +316,9 @@ def get_diff_position(seq1, seq2):
     Returns:
         Returns position where seq1 != seq2
     """
+    # If codon is NA treat as not same codon
     if seq1 == "NA":
-        return False
+        return 2
 
     ind_diff = [i for i in range(len(seq1)) if seq1[i] != seq2[i]]
     if len(ind_diff) > 1:
@@ -409,6 +410,7 @@ def main(args=None):
     var_count_dict = {"SNP": 0, "INS": 0, "DEL": 0}  # variant counts
     variants = OrderedDict()  # variant dict (merge codon)
     q_pos = deque([], maxlen=3)  # pos fifo queue (merge codon)
+    last_pos = ""
 
     # Create output directory
     make_dir(out_dir)
@@ -445,6 +447,12 @@ def main(args=None):
                     pass_test,
                     var_type,
                 ) = parse_ivar_line(line)
+
+                ## If pos is duplicated due to annotation skip lines
+                if pos == last_pos:
+                    continue
+
+                last_pos = pos
                 #####################
                 ## Process filters ##
                 #####################


### PR DESCRIPTION
BUG fixes in `ivar_variants_to_vcf` script.

- Ivar generates duplicated lines when using some gff that makes overlapping annotations for the same variant position. Now duplicated positions due to annotation are ignored for vcf format conversion. Fixes #321
-  Positions in intergenic areas are not annotated in ivar tsv file  (NA in codon REF/ALT column). `ivar_variants_to_tsv` skips merge codons for this positions. Fixes #317

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/viralrecon/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/viralrecon _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
