### PR TITLE
Fixed ivar_variants_to_vcf.py exception

### DIFF
--- a/bin/ivar_variants_to_vcf.py
+++ b/bin/ivar_variants_to_vcf.py
@@ -82,8 +82,8 @@ def parse_ivar_line(line):
     return:
         CHROM, POS, ID, REF, ALT, QUAL, INFO, FORMAT, REF_CODON, ALT_CODON, pass_test, var_type
     """
-    line = re.split("\t", line)
-
+    
+    line = line.strip("\n").split("\t")
     ## Assign intial fields to variables
     CHROM = line[0]
     POS = line[1]
@@ -92,7 +92,12 @@ def parse_ivar_line(line):
     ALT = line[3]
 
     ## REF/ALF depths and quals
-    REF_DP = int(line[4])
+    try:
+        REF_DP = int(line[4])
+    except ValueError:
+        print(line)
+        print(line[4])
+        exit(-1)
     REF_RV = int(line[5])
     REF_FW = REF_DP - REF_RV
     REF_QUAL = int(line[6])
@@ -390,7 +395,7 @@ def process_variants(variants, num_collapse):
     ref = ""
     alt = ""
     iter_variants = iter(variants)
-    for i in range(num_collapse):
+    for _ in range(num_collapse): # fixed notation
         var = next(iter_variants)
         ref += variants[var]["ref"]
         alt += variants[var]["alt"]
@@ -423,7 +428,7 @@ def main(args=None):
     #################################
     with open(args.file_in, "r") as fin:
         for line in fin:
-            if not re.match("REGION", line):
+            if "REGION" not in line:
 
                 ################
                 ## Parse line ##
@@ -548,30 +553,50 @@ def main(args=None):
         #######################
         ## handle last lines ##
         #######################
-        while len(q_pos) > 0:
-            fe_codon_ref = variants[next(iter(variants))]["ref_codon"]
-            fe_codon_alt = variants[next(iter(variants))]["alt_codon"]
-            num_collapse = check_merge_codons(q_pos, fe_codon_ref, fe_codon_alt)
-            (chrom, pos, id, ref, alt, qual, filter, info, format) = process_variants(
-                variants, num_collapse
-            )
+            while len(q_pos) > 0:  
+                try:
+                    fe_codon_ref = variants[next(iter(variants))]["ref_codon"]
+                    fe_codon_alt = variants[next(iter(variants))]["alt_codon"]
+                except StopIteration:
+                    break
+                else:
+                    num_collapse = check_merge_codons(q_pos, fe_codon_ref, fe_codon_alt)
+                    (chrom, pos, id, ref, alt, qual, filter, info, format) = process_variants(
+                        variants, num_collapse
+                    )
 
-            var_count_dict[var_type] += 1
-            write_vcf_line(
-                chrom, pos, id, ref, alt, filter, qual, info, format, args.file_out
-            )
-            ## Empty variants dict and queue accordingly
-            for i in range(num_collapse):
-                variants.popitem(last=False)
-                q_pos.popleft()
+                    var_count_dict[var_type] += 1
+                    write_vcf_line(
+                        chrom, pos, id, ref, alt, filter, qual, info, format, args.file_out
+                    )
+                    ## Empty variants dict and queue accordingly
+                    for _ in range(num_collapse):
+                        variants.popitem(last=False)
+                        q_pos.popleft()
+
+
 
     #############################################
     ##  variant counts to pass to MultiQC      ##
     #############################################
     var_count_list = [(k, str(v)) for k, v in sorted(var_count_dict.items())]
-    print("\t".join(["sample"] + [x[0] for x in var_count_list]))
-    print("\t".join([filename] + [x[1] for x in var_count_list]))
+    
+    # format output table a little more cleanly
+    #row_spacing = len(filename)
+ 
+    row = create_f_string(30, "<") # an arbitraily long value to fit most sample names
+    row += create_f_string(10) * len(var_count_list) # A spacing of ten looks pretty
 
+    headers = ["sample"]
+    headers.extend([x[0] for x in var_count_list])
+    data = [filename]
+    data.extend([x[1] for x in var_count_list])
+    print(row.format(*headers))
+    print(row.format(*data))
+
+def create_f_string(str_size, placement="^"):
+    row_size = "{: " + placement + str(str_size) + "}"
+    return row_size
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
<!--
# nf-core/viralrecon pull request

Many thanks for contributing to nf-core/viralrecon!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/viralrecon/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ]  The ivar_variants_to_vcf.py would occasionally throw an unhandled StopIteration exception when handling the last few lines of the VCF and codons were being merged. The proper changes to the code have been made, by adding the proper data structure. This created a logging issue were incorrect counts for each mutation type were sometimes incorrectly handled. This problem was altered by converting the q_pos deque structure to hold tuples instead of lists. The output of the files was also slightly tidied through the use of format strings. 

The traceback of the StopIteration exception is below.
```
Traceback (most recent call last):
  File "/mwells/viralrecon/bin/ivar_variants_to_vcf.py", line 577, in <module>
    sys.exit(main())
  File "mwells/viralrecon/bin/ivar_variants_to_vcf.py", line 552, in main
    fe_codon_ref = variants[next(iter(variants))]["ref_codon"]
StopIteration
```
