### PR TITLE
Wrap params string in file method

### DIFF
--- a/subworkflows/local/prepare_genome_illumina.nf
+++ b/subworkflows/local/prepare_genome_illumina.nf
@@ -76,7 +76,7 @@ workflow PREPARE_GENOME {
         if (params.kraken2_db) {
             if (params.kraken2_db.endsWith('.tar.gz')) {
                 UNTAR_KRAKEN2_DB (
-                    [ [:], params.kraken2_db ]
+                    [ [:], file(params.kraken2_db) ]
                 )
                 ch_kraken2_db = UNTAR_KRAKEN2_DB.out.untar.map { it[1] }
                 ch_versions   = ch_versions.mix(UNTAR_KRAKEN2_DB.out.versions)


### PR DESCRIPTION
When a custom kraken_db path is supplied, we were passing the string directly rather than wrapping it in a `file()` function call. This enables us to use `az://` or `s3://` locations to store the kraken_db path.

Without this adjustment, Nextflow exits early with the (semi-cryptic) message:

```
Unable to read script: '/.nextflow/assets/nf-core/viralrecon/./workflows/illumina.nf' -- cause: az://path-to/your/kraken2_human.tar.gz
```

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/viralrecon/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/viralrecon _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
