### PR TITLE
fix cardinality when params.bowtie2_index used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
           - "--spades_mode metaviral"
           - "--skip_plasmidid false --skip_asciigenome"
           - "--additional_annotation ./GCA_009858895.3_ASM985889v3_genomic.gtf.gz"
+          - "--bowtie2_index ./GCA_009858895.3_ASM985889v3_genomic.bt2.index.tar.gz"
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2
@@ -91,6 +92,11 @@ jobs:
         if: contains(matrix.parameters, 'additional_annotation')
         run: |
           wget https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/009/858/895/GCA_009858895.3_ASM985889v3/GCA_009858895.3_ASM985889v3_genomic.gtf.gz
+
+      - name: Download prebuild bowtie2 index
+        if: contains(matrix.parameters, 'bowtie2_index')
+        run: |
+          wget https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/GCA_009858895.3_ASM985889v3_genomic.200409.bt2.index.tar.gz
 
       - name: Run pipeline with various parameters
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           - "--spades_mode metaviral"
           - "--skip_plasmidid false --skip_asciigenome"
           - "--additional_annotation ./GCA_009858895.3_ASM985889v3_genomic.gtf.gz"
-          - "--bowtie2_index ./GCA_009858895.3_ASM985889v3_genomic.bt2.index.tar.gz"
+          - "--bowtie2_index ./GCA_009858895.3_ASM985889v3_genomic.200409.bt2.index.tar.gz"
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Thank you to everyone else that has contributed by reporting bugs, enhancements 
 - [[PR #417](https://github.com/nf-core/viralrecon/pull/417)] - Allow skipping of Freyja bootstrapping module & freyja module update
 - [[PR #434](https://github.com/nf-core/viralrecon/pull/434)] - Add blast result filtering through `min_contig_length` and `min_perc_contig_aligned`.
 - [[PR #438](https://github.com/nf-core/viralrecon/pull/438)] - Update fastp container to 0.23.4
+- [[PR #439](https://github.com/nf-core/viralrecon/pull/439)] - Fix cardinality issue when using `--bowtie2_index`
 
 ### Parameters
 

--- a/subworkflows/local/prepare_genome_illumina.nf
+++ b/subworkflows/local/prepare_genome_illumina.nf
@@ -158,12 +158,12 @@ workflow PREPARE_GENOME {
         if (bowtie2_index) {
             if (bowtie2_index.endsWith('.tar.gz')) {
                 UNTAR_BOWTIE2_INDEX (
-                    [ [:], bowtie2_index ]
+                    [ [:], file(bowtie2_index) ]
                 )
                 ch_bowtie2_index = UNTAR_BOWTIE2_INDEX.out.untar
                 ch_versions      = ch_versions.mix(UNTAR_BOWTIE2_INDEX.out.versions)
             } else {
-                ch_bowtie2_index = [ [:], bowtie2_index ]
+                ch_bowtie2_index = [ [:], file(bowtie2_index) ]
             }
         } else {
             BOWTIE2_BUILD (

--- a/subworkflows/local/prepare_genome_illumina.nf
+++ b/subworkflows/local/prepare_genome_illumina.nf
@@ -160,10 +160,10 @@ workflow PREPARE_GENOME {
                 UNTAR_BOWTIE2_INDEX (
                     [ [:], bowtie2_index ]
                 )
-                ch_bowtie2_index = UNTAR_BOWTIE2_INDEX.out.untar.map { it[1] }
+                ch_bowtie2_index = UNTAR_BOWTIE2_INDEX.out.untar
                 ch_versions      = ch_versions.mix(UNTAR_BOWTIE2_INDEX.out.versions)
             } else {
-                ch_bowtie2_index = Channel.value(file(bowtie2_index))
+                ch_bowtie2_index = [ [:], bowtie2_index ]
             }
         } else {
             BOWTIE2_BUILD (
@@ -246,7 +246,7 @@ workflow PREPARE_GENOME {
     gff                  = ch_gff                  // path: genome.gff
     fai                  = ch_fai                  // path: genome.fai
     chrom_sizes          = ch_chrom_sizes          // path: genome.sizes
-    bowtie2_index        = ch_bowtie2_index        // path: bowtie2/index/
+    bowtie2_index        = ch_bowtie2_index        // channel: [ [:], bowtie2/index/ ]
     primer_bed           = ch_primer_bed           // path: primer.bed
     primer_collapsed_bed = ch_primer_collapsed_bed // path: primer.collapsed.bed
     primer_fasta         = ch_primer_fasta         // path: primer.fasta


### PR DESCRIPTION
<!--
# nf-core/viralrecon pull request

Many thanks for contributing to nf-core/viralrecon!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/viralrecon/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

When given bowtie2_index from a param, it is read in as a value channel but when constructed from bowtie2 build it's a 
` [ [:] , path(bowtie2/index/) ]`. Meaning it's missing the meta.

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/viralrecon/tree/master/.github/CONTRIBUTING.md)
  - [x] If necessary, also make a PR on the nf-core/viralrecon _branch_ on the [nf-core/test-datasets] (https://github.com/nf-core/test-datasets) repository. (https://github.com/nf-core/test-datasets/pull/1300)
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
