### PR TITLE
Patch nf schema -  include integer & string as type for sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Thank you to everyone else that has contributed by reporting bugs, enhancements 
 - [[PR #439](https://github.com/nf-core/viralrecon/pull/439)] - Fix cardinality issue when using `--bowtie2_index`
 - [[PR #435](https://github.com/nf-core/viralrecon/pull/435)] - Changed to a patched cutadapt from nf-core modules, added `skip_noninternal_primers` param to allow users to process primers inside the pipeline, and added `threeprime_adapters` to determine whether primers are 3' or 5' adapters.
 - [[PR #446](https://github.com/nf-core/viralrecon/pull/446)] - Update nextclade & pangolin modules
+- [[PR #450](https://github.com/nf-core/viralrecon/pull/450)] - Patch nf schema -  include integer & string as type for sample
 
 ### Parameters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Thank you to everyone else that has contributed by reporting bugs, enhancements 
 - [[PR #439](https://github.com/nf-core/viralrecon/pull/439)] - Fix cardinality issue when using `--bowtie2_index`
 - [[PR #435](https://github.com/nf-core/viralrecon/pull/435)] - Changed to a patched cutadapt from nf-core modules, added `skip_noninternal_primers` param to allow users to process primers inside the pipeline, and added `threeprime_adapters` to determine whether primers are 3' or 5' adapters.
 - [[PR #446](https://github.com/nf-core/viralrecon/pull/446)] - Update nextclade & pangolin modules
-- [[PR #450](https://github.com/nf-core/viralrecon/pull/450)] - Patch nf schema -  include integer & string as type for sample
+- [[PR #450](https://github.com/nf-core/viralrecon/pull/450)] - Patch nf schema - include integer & string as type for sample
 
 ### Parameters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Note, since the pipeline is now using Nextflow DSL2, each process will be run wi
 | `multiqc`   | 1.14        | 1.19        |
 | `nextclade` | 2.12.0      | 3.8.2       |
 | `pangolin`  | 4.2         | 4.3         |
+| `nf-schema` |             | 2.2.1       |
 
 > **NB:** Dependency has been **updated** if both old and new version information is present.
 >

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -8,7 +8,7 @@
         "type": "object",
         "properties": {
             "sample": {
-
+                "type": ["string", "integer"],
                 "pattern": "^\\S+$",
                 "errorMessage": "Sample name must be provided and cannot contain spaces",
                 "meta": ["id"]

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -8,7 +8,7 @@
         "type": "object",
         "properties": {
             "sample": {
-                "type": "string",
+
                 "pattern": "^\\S+$",
                 "errorMessage": "Sample name must be provided and cannot contain spaces",
                 "meta": ["id"]

--- a/conf/test_nanopore.config
+++ b/conf/test_nanopore.config
@@ -35,7 +35,9 @@ params {
     primer_set_version = 3
 
     // variant calling options
-    freyja_repeats = 10
+    freyja_repeats    = 10
+    skip_freyja_boot  = true
+
 
     // Other parameters
     artic_minion_medaka_model = 's3://ngi-igenomes/test-data/viralrecon/minion_test/r941_min_high_g360_model.hdf5'

--- a/nextflow.config
+++ b/nextflow.config
@@ -313,7 +313,7 @@ manifest {
 
 // Nextflow plugins
 plugins {
-    id 'nf-schema@2.1.1' // Validation of pipeline parameters and creation of an input channel from a sample sheet
+    id 'nf-schema@2.2.1' // Validation of pipeline parameters and creation of an input channel from a sample sheet
 }
 
 validation {


### PR DESCRIPTION
<!--
# nf-core/viralrecon pull request

Many thanks for contributing to nf-core/viralrecon!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/viralrecon/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Currently, nf-schema would throw a misleading error message if a sample name contained only digits: 

`-> Entry 2: Error for field 'sample' (303452): Sample name must be provided and cannot contain spaces`

The newer version of nf-schema `v2.2.1` throws both the validation error message as the set error message: 
`->Entry 2: Error for field 'sample' (303452): Value is [integer] but should be [string] (Sample name must be provided and cannot contain spaces)`

Which is more clear. Additionally added that both strings and integers can be allowed as a type. 

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [X] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/viralrecon/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/viralrecon _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [X] Make sure your code lints (`nf-core lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [X] Usage Documentation in `docs/usage.md` is updated.
- [X] Output Documentation in `docs/output.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [X] `README.md` is updated (including new tool citations and authors/contributors).
