### PR TITLE
Short read variants and consensus depth

### DIFF
--- a/conf/modules_illumina.config
+++ b/conf/modules_illumina.config
@@ -395,7 +395,10 @@ if (!params.skip_variants) {
     if (variant_caller == 'ivar') {
         process {
             withName: 'IVAR_VARIANTS' {
-                ext.args = '-t 0.25 -q 20 -m 10'
+                ext.args = [
+                    '-t 0.25 -q 20 ',
+                    "-m ${params.min_depth}"
+                ].join(' ').trim()
                 ext.args2 = '--ignore-overlaps --count-orphans --no-BAQ --max-depth 0 --min-BQ 0'
                 publishDir = [
                     path: { "${params.outdir}/variants/ivar" },
@@ -445,7 +448,7 @@ if (!params.skip_variants) {
             withName: 'BCFTOOLS_MPILEUP' {
                 ext.args = '--ignore-overlaps --count-orphans --no-BAQ --max-depth 0 --min-BQ 20 --annotate FORMAT/AD,FORMAT/ADF,FORMAT/ADR,FORMAT/DP,FORMAT/SP,INFO/AD,INFO/ADF,INFO/ADR'
                 ext.args2 = '--ploidy 1 --keep-alts --keep-masked-ref --multiallelic-caller --variants-only'
-                ext.args3 = "--include 'INFO/DP>=10'"
+                ext.args3 = "--include 'INFO/DP>=${params.min_depth}'"
                 ext.prefix = { "${meta.id}.orig" }
                 publishDir = [
                     path: { "${params.outdir}/variants/bcftools" },
@@ -587,7 +590,10 @@ if (!params.skip_variants) {
     if (!params.skip_consensus && params.consensus_caller == 'ivar') {
         process {
             withName: 'IVAR_CONSENSUS' {
-                ext.args = '-t 0.75 -q 20 -m 10 -n N'
+                ext.args = [
+                    '-t 0.75 -q 20 -n N',
+                    "-m ${params.min_depth}"
+                ].join(' ').trim()
                 ext.args2 = '--count-orphans --no-BAQ --max-depth 0 --min-BQ 0 -aa'
                 ext.prefix = { "${meta.id}.consensus" }
                 publishDir = [
@@ -634,7 +640,6 @@ if (!params.skip_variants) {
 
             withName: 'MAKE_BED_MASK' {
                 ext.args = "-a --ignore-overlaps --count-orphans --no-BAQ --max-depth 0 --min-BQ 0"
-                ext.args2 = 10
                 ext.prefix = { "${meta.id}.coverage.masked" }
                 publishDir = [
                     path: { "${params.outdir}/variants/${variant_caller}/consensus/bcftools" },

--- a/modules/local/make_bed_mask.nf
+++ b/modules/local/make_bed_mask.nf
@@ -1,7 +1,7 @@
 process MAKE_BED_MASK {
     tag "$meta.id"
 
-    conda "conda-forge::python=3.9.5 bioconda::samtools=1.14"
+    conda "conda-forge::python=3.9.5 bioconda::samtools=1.21"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-1a35167f7a491c7086c13835aaa74b39f1f43979:6b5cffa1187cfccf2dc983ed3b5359d49b999eb0-0' :
         'quay.io/biocontainers/mulled-v2-1a35167f7a491c7086c13835aaa74b39f1f43979:6b5cffa1187cfccf2dc983ed3b5359d49b999eb0-0' }"
@@ -21,8 +21,8 @@ process MAKE_BED_MASK {
 
     script:  // This script is bundled with the pipeline, in nf-core/viralrecon/bin/
     def args = task.ext.args ?: ''
-    def args2 = task.ext.args2 ?: 10
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def min_depth = params.min_depth
     def mpileup = save_mpileup ? "| tee ${prefix}.mpileup" : ""
     """
     samtools \\
@@ -31,7 +31,7 @@ process MAKE_BED_MASK {
         --reference $fasta \\
         $bam \\
         $mpileup  \\
-        | awk -v OFS='\\t' '{print \$1, \$2-1, \$2, \$4}' | awk '\$4 < $args2' > lowcov_positions.txt
+        | awk -v OFS='\\t' '{print \$1, \$2-1, \$2, \$4}' | awk '\$4 < $min_depth' > lowcov_positions.txt
 
     make_bed_mask.py \\
         $vcf \\

--- a/modules/local/make_bed_mask.nf
+++ b/modules/local/make_bed_mask.nf
@@ -1,7 +1,7 @@
 process MAKE_BED_MASK {
     tag "$meta.id"
 
-    conda "conda-forge::python=3.9.5 bioconda::samtools=1.21"
+    conda "conda-forge::python=3.12.8 bioconda::samtools=1.21"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-1a35167f7a491c7086c13835aaa74b39f1f43979:6b5cffa1187cfccf2dc983ed3b5359d49b999eb0-0' :
         'quay.io/biocontainers/mulled-v2-1a35167f7a491c7086c13835aaa74b39f1f43979:6b5cffa1187cfccf2dc983ed3b5359d49b999eb0-0' }"

--- a/nextflow.config
+++ b/nextflow.config
@@ -79,6 +79,7 @@ params {
     variant_caller             = null
     consensus_caller           = 'bcftools'
     min_mapped_reads           = 1000
+    min_depth                  = 10
     ivar_trim_noprimer         = false
     ivar_trim_offset           = null
     filter_duplicates          = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -431,6 +431,12 @@
                     "description": "Minimum number of mapped reads below which samples are removed from further processing. Some downstream steps in the pipeline will fail if this threshold is too low.",
                     "fa_icon": "fas fa-hand-paper"
                 },
+                "min_depth": {
+                    "type": "integer",
+                    "default": 10,
+                    "description": "Minimum depth of mapped reads below which bases are masked. Variant calling also discard bases with depth below this threshold.",
+                    "fa_icon": "fas fa-hand-paper"
+                },
                 "ivar_trim_noprimer": {
                     "type": "boolean",
                     "description": "This option unsets the '-e' parameter in 'ivar trim' to discard reads without primers.",


### PR DESCRIPTION
**Description:**

#447 

This PR adds the `min_depth` parameter for Illumina variant/consensus calling. The Nanopore _artic_make_depth_mask_ remains unchanged. MultiQC _mosdepth coverage > `min_depth`_ has not been added either.

**Key Changes:**
- The parameter has been added to the pipeline's schema and config
- MAKE_BED_MASK — new variable `min_depth` instead of args2
- MAKE_BED_MASK — updated Python and Samtools versions
- Illumina config is updated to include the new parameter

<!--
# nf-core/viralrecon pull request

Many thanks for contributing to nf-core/viralrecon!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/viralrecon/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/viralrecon/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/viralrecon _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
