### PR TITLE
Fix empty iVar variants MultiQC field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Thank you to everyone else that has contributed by reporting bugs, enhancements 
 - [[PR #452](https://github.com/nf-core/viralrecon/pull/452)] - Fix `ch_blast_db` to have correct cardinality for blast/blastn
 - [[PR #486](https://github.com/nf-core/viralrecon/pull/486)] - Updated local modules version
 - [[PR #491](https://github.com/nf-core/viralrecon/pull/491)] - Remove asciiigenome
+- [[PR #493](https://github.com/nf-core/viralrecon/pull/493)] - Fix empty iVar variants MultiQC field
 
 ### Parameters
 

--- a/bin/ivar_variants_to_vcf.py
+++ b/bin/ivar_variants_to_vcf.py
@@ -737,11 +737,12 @@ class IvarVariants:
             processed_vcf = processed_vcf.rename(
                 columns={"REGION": "#CHROM", "FILENAME": self.filename}
             )
+            self.vcf = processed_vcf
             if consensus:
                 filepath = self.file_out
             else:
-                basename = os.path.splitext(os.path.basename(self.file_out))[0]
-                filename = str(basename) + "_all_hap.vcf"
+                self.basename = os.path.splitext(os.path.basename(self.file_out))[0]
+                filename = str(self.basename) + "_all_hap.vcf"
                 filepath = os.path.join(os.path.dirname(self.file_out), filename)
             with open(filepath, "w") as file_out:
                 file_out.write(vcf_header + "\n")
@@ -751,6 +752,27 @@ class IvarVariants:
         export_vcf(vcf_table, consensus=False)
         return
 
+    def write_stdout(self):
+        """Summarize variant counts to pass to MultiQC"""
+        variant_types: pd.Series = self.vcf["INFO"].str.replace("TYPE=", "")
+        counts = variant_types.value_counts()
+        var_count_dict = counts.to_dict()
+
+        var_count_list = [(k, str(v)) for k, v in sorted(var_count_dict.items())]
+
+        def create_f_string(str_size, placement="^"):
+            row_size = "{: " + placement + str(str_size) + "}"
+            return row_size
+
+        row = create_f_string(30, "<")  # an arbitraily long value to fit most sample names
+        row += create_f_string(10) * len(var_count_list)  # A spacing of ten looks pretty
+
+        headers = ["sample"]
+        headers.extend([x[0] for x in var_count_list])
+        data = [self.basename]
+        data.extend([x[1] for x in var_count_list])
+        print(row.format(*headers))
+        print(row.format(*data))
 
 def make_dir(path):
     """
@@ -784,6 +806,7 @@ def main(args=None):
         fasta=args.fasta,
     )
     ivar_to_vcf.write_vcf()
+    ivar_to_vcf.write_stdout()
     return
 
 

--- a/bin/ivar_variants_to_vcf.py
+++ b/bin/ivar_variants_to_vcf.py
@@ -754,10 +754,11 @@ class IvarVariants:
 
     def write_stdout(self):
         """Summarize variant counts to pass to MultiQC"""
-        variant_types: pd.Series = self.processed_vcf["INFO"].str.replace("TYPE=", "")
-        counts = variant_types.value_counts()
-        var_count_dict = counts.to_dict()
+        variant_types = ["SNP", "DEL", "INS"]
+        variant_col: pd.Series = self.processed_vcf["INFO"].str.replace("TYPE=", "")
+        variant_counts = variant_col.value_counts().to_dict()
 
+        var_count_dict = {var_type: variant_counts.get(var_type, 0) for var_type in variant_types}
         var_count_list = [(k, str(v)) for k, v in sorted(var_count_dict.items())]
 
         def create_f_string(str_size, placement="^"):

--- a/bin/ivar_variants_to_vcf.py
+++ b/bin/ivar_variants_to_vcf.py
@@ -737,7 +737,7 @@ class IvarVariants:
             processed_vcf = processed_vcf.rename(
                 columns={"REGION": "#CHROM", "FILENAME": self.filename}
             )
-            self.vcf = processed_vcf
+            self.processed_vcf = processed_vcf
             if consensus:
                 filepath = self.file_out
             else:
@@ -754,7 +754,7 @@ class IvarVariants:
 
     def write_stdout(self):
         """Summarize variant counts to pass to MultiQC"""
-        variant_types: pd.Series = self.vcf["INFO"].str.replace("TYPE=", "")
+        variant_types: pd.Series = self.processed_vcf["INFO"].str.replace("TYPE=", "")
         counts = variant_types.value_counts()
         var_count_dict = counts.to_dict()
 

--- a/modules/local/ivar_variants_to_vcf.nf
+++ b/modules/local/ivar_variants_to_vcf.nf
@@ -1,7 +1,7 @@
 process IVAR_VARIANTS_TO_VCF {
     tag "$meta.id"
 
-    conda "conda-forge::python:3.13.2 conda-forge::matplotlib=3.10.1 conda-forge::pandas=2.2.3 conda-forge::r-sys=3.4.3 conda-forge::regex=2024.11.6 conda-forge::scipy=1.15.2 conda-forge::biopython=1.85"
+    conda "conda-forge::python=3.13.2 conda-forge::matplotlib=3.10.1 conda-forge::pandas=2.2.3 conda-forge::r-sys=3.4.3 conda-forge::regex=2024.11.6 conda-forge::scipy=1.15.2 conda-forge::biopython=1.85"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/79/79e3c1e22b660e6a4f3655b1aeced00469a42bdff308be6e44910f4de0210ea0/data' :
         'community.wave.seqera.io/library/biopython_matplotlib_pandas_python_pruned:46d87e2ad1f8a063' }"


### PR DESCRIPTION
<!--
# nf-core/viralrecon pull request

Many thanks for contributing to nf-core/viralrecon!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/viralrecon/tree/master/.github/CONTRIBUTING.md)
-->

The pipeline still works without this fix, but the MultiQC report is missing the “VARIANTS: Total variants (iVar)” section.
I basically took the code from the previous version of ivar_variants_to_vcf.py and wrapped it in a method inside the class.

I guess I didn't properly test it like #470 insists, but this fix is related to that issue.

[process ref](https://github.com/nf-core/viralrecon/blob/dev/modules/local/ivar_variants_to_vcf.nf#L32)

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/viralrecon/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/viralrecon _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
