### PR TITLE
Fix strict syntax errors

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -39,8 +39,8 @@ process {
     }
 }
 
-if (params.platform == 'nanopore') {
-    includeConfig 'modules_nanopore.config'
-} else if (params.platform == 'illumina') {
-    includeConfig 'modules_illumina.config'
-}
+includeConfig (
+    params.platform == 'nanopore' ? 'modules_nanopore.config' :
+    params.platform == 'illumina' ? 'modules_illumina.config' :
+    '/dev/null'
+)

--- a/conf/modules_illumina.config
+++ b/conf/modules_illumina.config
@@ -10,10 +10,6 @@
 ----------------------------------------------------------------------------------------
 */
 
-def variant_caller = params.variant_caller
-if (!variant_caller) { variant_caller = params.trim_primers ? 'ivar' : 'bcftools' }
-def assemblers = params.assemblers ? params.assemblers.split(',').collect{ it.trim().toLowerCase() } : []
-
 //
 // Pre-processing and general configuration options
 //
@@ -55,7 +51,6 @@ process {
     }
 }
 
-if (!params.skip_fastqc) {
     process {
         withName: '.*:.*:FASTQ_TRIM_FASTP_FASTQC:FASTQC_RAW' {
             ext.args = '--quiet'
@@ -66,9 +61,7 @@ if (!params.skip_fastqc) {
             ]
         }
     }
-}
 
-if (!params.skip_fastp) {
     process {
         withName: 'FASTP' {
             ext.args = '--cut_front --cut_tail --trim_poly_x --cut_mean_quality 30 --qualified_quality_phred 30 --unqualified_percent_limit 10 --length_required 50'
@@ -93,7 +86,6 @@ if (!params.skip_fastp) {
         }
     }
 
-    if (!params.skip_fastqc) {
         process {
             withName: '.*:.*:FASTQ_TRIM_FASTP_FASTQC:FASTQC_TRIM' {
                 ext.args = '--quiet'
@@ -104,10 +96,7 @@ if (!params.skip_fastp) {
                 ]
             }
         }
-    }
-}
 
-if (!params.skip_kraken2) {
     process {
         withName: 'KRAKEN2_BUILD' {
             publishDir = [
@@ -127,13 +116,11 @@ if (!params.skip_kraken2) {
             ]
         }
     }
-}
 
 //
 // Variant calling configuration options
 //
 
-if (!params.skip_variants) {
     process {
         withName: 'BOWTIE2_BUILD' {
             ext.args = '--seed 1'
@@ -190,7 +177,6 @@ if (!params.skip_variants) {
         }
     }
 
-    if (!params.skip_freyja) {
         process {
             withName: 'FREYJA_VARIANTS' {
                 ext.args = {}
@@ -232,9 +218,7 @@ if (!params.skip_variants) {
                 ]
             }
         }
-    }
 
-    if (!params.skip_ivar_trim && params.trim_primers) {
         process {
             withName: 'IVAR_TRIM' {
                 ext.args = [
@@ -278,9 +262,7 @@ if (!params.skip_variants) {
                 ]
             }
         }
-    }
 
-    if (!params.skip_markduplicates) {
         process {
             withName: 'PICARD_MARKDUPLICATES' {
                 ext.args = [
@@ -319,9 +301,7 @@ if (!params.skip_variants) {
                 ]
             }
         }
-    }
 
-    if (!params.skip_picard_metrics) {
         process {
             withName: 'PICARD_COLLECTMULTIPLEMETRICS' {
                 ext.args = '--VALIDATION_STRINGENCY LENIENT --TMP_DIR tmp'
@@ -339,9 +319,7 @@ if (!params.skip_variants) {
                 ]
             }
         }
-    }
 
-    if (!params.skip_mosdepth) {
         process {
             withName: 'MOSDEPTH_GENOME' {
                 ext.args = '--fast-mode --by 200'
@@ -362,7 +340,6 @@ if (!params.skip_variants) {
             }
         }
 
-        if (params.trim_primers) {
             process {
                 withName: 'COLLAPSE_PRIMERS' {
                     publishDir = [
@@ -391,14 +368,12 @@ if (!params.skip_variants) {
                     ]
                 }
             }
-        }
-    }
 
-    if (variant_caller == 'ivar') {
-        if (params.genome == 'codfreq' || params.genome == 'NC_001802.1' || params.perform_hiv_resistance) {
             process {
                 withName: 'IVAR_VARIANTS' {
-                    ext.args = '-t 0.01 -q 30 -m 50'
+                    ext.args = (params.genome == 'codfreq' || params.genome == 'NC_001802.1' || params.perform_hiv_resistance)
+                        ? '-t 0.01 -q 30 -m 50'
+                        : '-t 0.25 -q 20 -m 10'
                     ext.args2 = '--ignore-overlaps --count-orphans --no-BAQ --max-depth 0 --min-BQ 0'
                     publishDir = [
                         path: { "${params.outdir}/variants/ivar" },
@@ -407,19 +382,7 @@ if (!params.skip_variants) {
                     ]
                 }
             }
-        } else {
-            process {
-                withName: 'IVAR_VARIANTS' {
-                    ext.args = '-t 0.25 -q 20 -m 10'
-                    ext.args2 = '--ignore-overlaps --count-orphans --no-BAQ --max-depth 0 --min-BQ 0'
-                    publishDir = [
-                        path: { "${params.outdir}/variants/ivar" },
-                        mode: params.publish_dir_mode,
-                        saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-                    ]
-                }
-            }
-        }
+
         process {
             withName: 'IVAR_VARIANTS_TO_VCF' {
                 ext.args = params.trim_primers ? '--ignore_strand_bias' : ''
@@ -455,9 +418,7 @@ if (!params.skip_variants) {
                 ]
             }
         }
-    }
 
-    if (variant_caller == 'bcftools') {
         process {
             withName: 'BCFTOOLS_MPILEUP' {
                 ext.args = '--ignore-overlaps --count-orphans --no-BAQ --max-depth 0 --min-BQ 20 --annotate FORMAT/AD,FORMAT/ADF,FORMAT/ADR,FORMAT/DP,FORMAT/SP,INFO/AD,INFO/ADF,INFO/ADR'
@@ -498,9 +459,7 @@ if (!params.skip_variants) {
                 ]
             }
         }
-    }
 
-    if (!params.skip_snpeff) {
         process {
             withName: '.*:.*:PREPARE_GENOME:SNPEFF_BUILD' {
                 publishDir = [
@@ -512,7 +471,7 @@ if (!params.skip_variants) {
             }
             withName: '.*:.*:.*:.*:SNPEFF_SNPSIFT:SNPEFF_ANN' {
                 publishDir = [
-                    path: { "${params.outdir}/variants/${variant_caller}/snpeff" },
+                    path: { "${params.outdir}/variants/${params.variant_caller}/snpeff" },
                     mode: params.publish_dir_mode,
                     pattern: "*.{csv,txt,html}"
                 ]
@@ -521,7 +480,7 @@ if (!params.skip_variants) {
             withName: '.*:.*:.*:.*:SNPEFF_SNPSIFT:.*:TABIX_BGZIP' {
                 ext.prefix = { "${meta.id}.snpeff" }
                 publishDir = [
-                    path: { "${params.outdir}/variants/${variant_caller}/snpeff" },
+                    path: { "${params.outdir}/variants/${params.variant_caller}/snpeff" },
                     mode: params.publish_dir_mode,
                     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                 ]
@@ -530,7 +489,7 @@ if (!params.skip_variants) {
             withName: '.*:.*:.*:.*:SNPEFF_SNPSIFT:.*:.*:TABIX_TABIX' {
                 ext.args = '-p vcf -f'
                 publishDir = [
-                    path: { "${params.outdir}/variants/${variant_caller}/snpeff" },
+                    path: { "${params.outdir}/variants/${params.variant_caller}/snpeff" },
                     mode: params.publish_dir_mode,
                     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                 ]
@@ -539,7 +498,7 @@ if (!params.skip_variants) {
             withName: '.*:.*:.*:.*:SNPEFF_SNPSIFT:.*:.*:BCFTOOLS_STATS' {
                 ext.prefix = { "${meta.id}.snpeff" }
                 publishDir = [
-                    path: { "${params.outdir}/variants/${variant_caller}/snpeff/bcftools_stats" },
+                    path: { "${params.outdir}/variants/${params.variant_caller}/snpeff/bcftools_stats" },
                     mode: params.publish_dir_mode,
                     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                 ]
@@ -547,44 +506,40 @@ if (!params.skip_variants) {
 
             withName: '.*:.*:.*:.*:SNPEFF_SNPSIFT:SNPSIFT_EXTRACTFIELDS' {
                 publishDir = [
-                    path: { "${params.outdir}/variants/${variant_caller}/snpeff" },
+                    path: { "${params.outdir}/variants/${params.variant_caller}/snpeff" },
                     mode: params.publish_dir_mode,
                     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                 ]
             }
         }
-    }
 
-    if (!params.skip_variants_long_table) {
         process {
             withName: '.*:.*:VARIANTS_LONG_TABLE:BCFTOOLS_QUERY' {
                 ext.args = [
-                    variant_caller == 'ivar'     ? "-H -f '%CHROM\\t%POS\\t%REF\\t%ALT\\t%FILTER\\t[%DP\\t]\\t[%REF_DP\\t]\\t[%ALT_DP\\t]\\n'" : '',
-                    variant_caller == 'bcftools' ? "-H -f '%CHROM\\t%POS\\t%REF\\t%ALT\\t%FILTER\\t[%DP\\t]\\t[%AD\\t]\\n'" : '',
+                    params.variant_caller == 'ivar'     ? "-H -f '%CHROM\\t%POS\\t%REF\\t%ALT\\t%FILTER\\t[%DP\\t]\\t[%REF_DP\\t]\\t[%ALT_DP\\t]\\n'" : '',
+                    params.variant_caller == 'bcftools' ? "-H -f '%CHROM\\t%POS\\t%REF\\t%ALT\\t%FILTER\\t[%DP\\t]\\t[%AD\\t]\\n'" : '',
                 ].join(' ').trim()
                 ext.prefix = { "${meta.id}.bcftools_query" }
                 publishDir = [
-                    path: { "${params.outdir}/variants/${variant_caller}" },
+                    path: { "${params.outdir}/variants/${params.variant_caller}" },
                     enabled: false
                 ]
             }
 
             withName: '.*:.*:VARIANTS_LONG_TABLE:MAKE_VARIANTS_LONG_TABLE' {
-                ext.args = "--variant_caller ${variant_caller}"
+                ext.args = "--variant_caller ${params.variant_caller}"
                 publishDir = [
-                    path: { "${params.outdir}/variants/${variant_caller}" },
+                    path: { "${params.outdir}/variants/${params.variant_caller}" },
                     mode: params.publish_dir_mode,
                     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                 ]
             }
         }
-    }
 
-    if (params.additional_annotation) {
         process {
             withName: '.*:VIRALRECON:GUNZIP_GFF' {
                 publishDir = [
-                    path: { "${params.outdir}/variants/${variant_caller}/additional_annotation/genome" },
+                    path: { "${params.outdir}/variants/${params.variant_caller}/additional_annotation/genome" },
                     mode: params.publish_dir_mode,
                     saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
                     enabled: params.save_reference
@@ -593,7 +548,7 @@ if (!params.skip_variants) {
 
             withName: '.*:.*:ADDITIONAL_ANNOTATION:SNPEFF_BUILD' {
                 publishDir = [
-                    path: { "${params.outdir}/variants/${variant_caller}/additional_annotation/genome" },
+                    path: { "${params.outdir}/variants/${params.variant_caller}/additional_annotation/genome" },
                     mode: params.publish_dir_mode,
                     saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
                     enabled: params.save_reference
@@ -602,7 +557,7 @@ if (!params.skip_variants) {
 
             withName: '.*:.*:ADDITIONAL_ANNOTATION:SNPEFF_ANN' {
                 publishDir = [
-                    path: { "${params.outdir}/variants/${variant_caller}/additional_annotation/snpeff" },
+                    path: { "${params.outdir}/variants/${params.variant_caller}/additional_annotation/snpeff" },
                     mode: params.publish_dir_mode,
                     pattern: "*.{csv,txt,html}"
                 ]
@@ -611,7 +566,7 @@ if (!params.skip_variants) {
             withName: '.*:.*:ADDITIONAL_ANNOTATION:.*:TABIX_BGZIP' {
                 ext.prefix = { "${meta.id}.snpeff" }
                 publishDir = [
-                    path: { "${params.outdir}/variants/${variant_caller}/additional_annotation/snpeff" },
+                    path: { "${params.outdir}/variants/${params.variant_caller}/additional_annotation/snpeff" },
                     mode: params.publish_dir_mode,
                     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                 ]
@@ -620,7 +575,7 @@ if (!params.skip_variants) {
             withName: '.*:.*:ADDITIONAL_ANNOTATION:.*:VCF_TABIX_STATS:TABIX_TABIX' {
                 ext.args = '-p vcf -f'
                 publishDir = [
-                    path: { "${params.outdir}/variants/${variant_caller}/additional_annotation/snpeff" },
+                    path: { "${params.outdir}/variants/${params.variant_caller}/additional_annotation/snpeff" },
                     mode: params.publish_dir_mode,
                     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                 ]
@@ -629,7 +584,7 @@ if (!params.skip_variants) {
             withName: '.*:.*:ADDITIONAL_ANNOTATION:.*:.*:BCFTOOLS_STATS' {
                 ext.prefix = { "${meta.id}.snpeff" }
                 publishDir = [
-                    path: { "${params.outdir}/variants/${variant_caller}/additional_annotation/snpeff/bcftools_stats" },
+                    path: { "${params.outdir}/variants/${params.variant_caller}/additional_annotation/snpeff/bcftools_stats" },
                     mode: params.publish_dir_mode,
                     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                 ]
@@ -637,7 +592,7 @@ if (!params.skip_variants) {
 
             withName: '.*:.*:ADDITIONAL_ANNOTATION:SNPSIFT_EXTRACTFIELDS' {
                 publishDir = [
-                    path: { "${params.outdir}/variants/${variant_caller}/additional_annotation/snpeff" },
+                    path: { "${params.outdir}/variants/${params.variant_caller}/additional_annotation/snpeff" },
                     mode: params.publish_dir_mode,
                     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                 ]
@@ -645,43 +600,42 @@ if (!params.skip_variants) {
 
             withName: '.*:.*:ADDITIONAL_ANNOTATION:BCFTOOLS_QUERY' {
                 ext.args = [
-                    variant_caller == 'ivar'     ? "-H -f '%CHROM\\t%POS\\t%REF\\t%ALT\\t%FILTER\\t[%DP\\t]\\t[%REF_DP\\t]\\t[%ALT_DP\\t]\\n'" : '',
-                    variant_caller == 'bcftools' ? "-H -f '%CHROM\\t%POS\\t%REF\\t%ALT\\t%FILTER\\t[%DP\\t]\\t[%AD\\t]\\n'" : '',
+                    params.variant_caller == 'ivar'     ? "-H -f '%CHROM\\t%POS\\t%REF\\t%ALT\\t%FILTER\\t[%DP\\t]\\t[%REF_DP\\t]\\t[%ALT_DP\\t]\\n'" : '',
+                    params.variant_caller == 'bcftools' ? "-H -f '%CHROM\\t%POS\\t%REF\\t%ALT\\t%FILTER\\t[%DP\\t]\\t[%AD\\t]\\n'" : '',
                 ].join(' ').trim()
                 ext.prefix = { "${meta.id}.bcftools_query" }
                 publishDir = [
-                    path: { "${params.outdir}/variants/${variant_caller}/additional_annotation/" },
+                    path: { "${params.outdir}/variants/${params.variant_caller}/additional_annotation/" },
                     mode: params.publish_dir_mode,
                     enabled: true
                 ]
             }
 
             withName: '.*:.*:ADDITIONAL_ANNOTATION:MAKE_VARIANTS_LONG_TABLE_ADDITIONAL' {
-                ext.args = "--variant_caller ${variant_caller} --output_file 'additional_variants_long_table.csv'"
+                ext.args = "--variant_caller ${params.variant_caller} --output_file 'additional_variants_long_table.csv'"
                 publishDir = [
-                    path: { "${params.outdir}/variants/${variant_caller}/additional_annotation" },
+                    path: { "${params.outdir}/variants/${params.variant_caller}/additional_annotation" },
                     mode: params.publish_dir_mode,
                     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                 ]
             }
         }
-    }
 
-    if (!params.skip_consensus && params.consensus_caller == 'ivar') {
-        if (params.genome == 'codfreq' || params.genome == 'NC_001802.1' || params.perform_hiv_resistance) {
             process {
                 withName: 'IVAR_CONSENSUS' {
-                    ext.args = '-t 0.9 -q 30 -m 50 -n N'
+                    ext.args = (params.genome == 'codfreq' || params.genome == 'NC_001802.1' || params.perform_hiv_resistance)
+                        ? '-t 0.9 -q 30 -m 50 -n N'
+                        : '-t 0.75 -q 20 -m 10 -n N'
                     ext.args2 = '--count-orphans --no-BAQ --max-depth 0 --min-BQ 0 -aa'
                     ext.prefix = { "${meta.id}.consensus" }
                     publishDir = [
                         [
-                            path: { "${params.outdir}/variants/${variant_caller}/consensus/ivar" },
+                            path: { "${params.outdir}/variants/${params.variant_caller}/consensus/ivar" },
                             mode: params.publish_dir_mode,
                             pattern: "*.{fa,txt}",
                         ],
                         [
-                            path: { "${params.outdir}/variants/${variant_caller}/consensus/ivar" },
+                            path: { "${params.outdir}/variants/${params.variant_caller}/consensus/ivar" },
                             mode: params.publish_dir_mode,
                             pattern: "*.mpileup",
                             enabled: params.save_mpileup
@@ -689,41 +643,17 @@ if (!params.skip_variants) {
                     ]
                 }
             }
-        } else {
-            process {
-                withName: 'IVAR_CONSENSUS' {
-                    ext.args = '-t 0.75 -q 20 -m 10 -n N'
-                    ext.args2 = '--count-orphans --no-BAQ --max-depth 0 --min-BQ 0 -aa'
-                    ext.prefix = { "${meta.id}.consensus" }
-                    publishDir = [
-                        [
-                            path: { "${params.outdir}/variants/${variant_caller}/consensus/ivar" },
-                            mode: params.publish_dir_mode,
-                            pattern: "*.{fa,txt}",
-                        ],
-                        [
-                            path: { "${params.outdir}/variants/${variant_caller}/consensus/ivar" },
-                            mode: params.publish_dir_mode,
-                            pattern: "*.mpileup",
-                            enabled: params.save_mpileup
-                        ]
-                    ]
-                }
-            }
-        }
-    }
 
-    if (!params.skip_consensus && params.consensus_caller == 'bcftools') {
         process {
             withName: 'BCFTOOLS_FILTER' {
                 ext.args   = [
                     '--output-type z',
-                    variant_caller == 'ivar'     ? "--include 'FORMAT/ALT_FREQ >= 0.75'"           : '',
-                    variant_caller == 'bcftools' ? "--include 'FORMAT/AD[:1] / FORMAT/DP >= 0.75'" : '',
+                    params.variant_caller == 'ivar'     ? "--include 'FORMAT/ALT_FREQ >= 0.75'"           : '',
+                    params.variant_caller == 'bcftools' ? "--include 'FORMAT/AD[:1] / FORMAT/DP >= 0.75'" : '',
                 ].join(' ').trim()
                 ext.prefix = { "${meta.id}.filtered" }
                 publishDir = [
-                    path: { "${params.outdir}/variants/${variant_caller}/consensus/bcftools" },
+                    path: { "${params.outdir}/variants/${params.variant_caller}/consensus/bcftools" },
                     mode: params.publish_dir_mode,
                     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                 ]
@@ -732,7 +662,7 @@ if (!params.skip_variants) {
             withName: '.*:.*:CONSENSUS_BCFTOOLS:TABIX_TABIX' {
                 ext.args = '-p vcf -f'
                 publishDir = [
-                    path: { "${params.outdir}/variants/${variant_caller}/consensus/bcftools" },
+                    path: { "${params.outdir}/variants/${params.variant_caller}/consensus/bcftools" },
                     mode: params.publish_dir_mode,
                     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                 ]
@@ -743,7 +673,7 @@ if (!params.skip_variants) {
                 ext.args2 = 10
                 ext.prefix = { "${meta.id}.coverage.masked" }
                 publishDir = [
-                    path: { "${params.outdir}/variants/${variant_caller}/consensus/bcftools" },
+                    path: { "${params.outdir}/variants/${params.variant_caller}/consensus/bcftools" },
                     mode: params.publish_dir_mode,
                     pattern: "*.mpileup",
                     enabled: params.save_mpileup
@@ -753,7 +683,7 @@ if (!params.skip_variants) {
             withName: 'BEDTOOLS_MERGE' {
                 ext.prefix = { "${meta.id}.coverage.merged" }
                 publishDir = [
-                    path: { "${params.outdir}/variants/${variant_caller}/consensus/bcftools" },
+                    path: { "${params.outdir}/variants/${params.variant_caller}/consensus/bcftools" },
                     enabled: false
                 ]
             }
@@ -761,7 +691,7 @@ if (!params.skip_variants) {
             withName: 'BEDTOOLS_MASKFASTA' {
                 ext.prefix = { "${meta.id}.masked" }
                 publishDir = [
-                    path: { "${params.outdir}/variants/${variant_caller}/consensus/bcftools" },
+                    path: { "${params.outdir}/variants/${params.variant_caller}/consensus/bcftools" },
                     enabled: false
                 ]
             }
@@ -769,7 +699,7 @@ if (!params.skip_variants) {
             withName: 'BCFTOOLS_CONSENSUS' {
                 ext.prefix = { "${meta.id}" }
                 publishDir = [
-                    path: { "${params.outdir}/variants/${variant_caller}/consensus/bcftools" },
+                    path: { "${params.outdir}/variants/${params.variant_caller}/consensus/bcftools" },
                     enabled: false
                 ]
             }
@@ -777,104 +707,94 @@ if (!params.skip_variants) {
             withName: 'RENAME_FASTA_HEADER' {
                 ext.prefix = { "${meta.id}.consensus" }
                 publishDir = [
-                    path: { "${params.outdir}/variants/${variant_caller}/consensus/bcftools" },
+                    path: { "${params.outdir}/variants/${params.variant_caller}/consensus/bcftools" },
                     mode: params.publish_dir_mode,
                     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                 ]
             }
         }
-    }
 
-    if (!params.skip_consensus) {
-        if (!params.skip_pangolin) {
             process {
                 withName: 'PANGOLIN_UPDATEDATA' {
                     publishDir = [
-                        path: { "${params.outdir}/variants/${variant_caller}/consensus/${params.consensus_caller}/pangolin" },
+                        path: { "${params.outdir}/variants/${params.variant_caller}/consensus/${params.consensus_caller}/pangolin" },
                         mode: params.publish_dir_mode,
                         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                     ]
                 }
                 withName: 'PANGOLIN_RUN' {
                     publishDir = [
-                        path: { "${params.outdir}/variants/${variant_caller}/consensus/${params.consensus_caller}/pangolin" },
+                        path: { "${params.outdir}/variants/${params.variant_caller}/consensus/${params.consensus_caller}/pangolin" },
                         mode: params.publish_dir_mode,
                         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                     ]
                 }
                 withName: 'UNTAR_PANGODB' {
                     publishDir = [
-                        path: { "${params.outdir}/variants/${variant_caller}/consensus/${params.consensus_caller}/pangolin" },
+                        path: { "${params.outdir}/variants/${params.variant_caller}/consensus/${params.consensus_caller}/pangolin" },
                         enabled: false
                     ]
                 }
             }
-        }
 
-        if (!params.skip_nextclade) {
             process {
                 withName: 'NEXTCLADE_RUN' {
                     publishDir = [
-                        path: { "${params.outdir}/variants/${variant_caller}/consensus/${params.consensus_caller}/nextclade" },
+                        path: { "${params.outdir}/variants/${params.variant_caller}/consensus/${params.consensus_caller}/nextclade" },
                         mode: params.publish_dir_mode,
                         saveAs: { filename -> filename.endsWith(".csv") && !filename.endsWith("errors.csv") && !filename.endsWith("insertions.csv") ? filename : null }
                     ]
                 }
             }
-        }
 
-        if (!params.skip_variants_quast) {
             process {
                 withName: '.*:.*:CONSENSUS_.*:.*:QUAST' {
                     ext.prefix = { "${meta.id}.consensus" }
                     publishDir = [
-                        path: { "${params.outdir}/variants/${variant_caller}/consensus/${params.consensus_caller}" },
+                        path: { "${params.outdir}/variants/${params.variant_caller}/consensus/${params.consensus_caller}" },
                         mode: params.publish_dir_mode,
                         pattern: "quast.consensus"
                     ]
                 }
             }
-        }
 
-        if (!params.skip_consensus_plots) {
             process {
                 withName: 'PLOT_BASE_DENSITY' {
                     ext.prefix = { "${meta.id}.consensus" }
                     publishDir = [
-                        path: { "${params.outdir}/variants/${variant_caller}/consensus/${params.consensus_caller}/base_qc" },
+                        path: { "${params.outdir}/variants/${params.variant_caller}/consensus/${params.consensus_caller}/base_qc" },
                         mode: params.publish_dir_mode,
                         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                     ]
                 }
             }
-        }
-        if (params.perform_hiv_resistance) {
+
             process {
                 withName: 'SIERRALOCAL' {
                     ext.args = '-alignment post'
                     publishDir = [
-                        path: { "${params.outdir}/variants/${variant_caller}/consensus/${params.consensus_caller}/hiv_resistance/sierra-local" },
+                        path: { "${params.outdir}/variants/${params.variant_caller}/consensus/${params.consensus_caller}/hiv_resistance/sierra-local" },
                         mode: params.publish_dir_mode,
                         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                     ]
                 }
                 withName: 'LIFTOFF' {
                     publishDir = [
-                        path: { "${params.outdir}/variants/${variant_caller}/consensus/${params.consensus_caller}/hiv_resistance/liftoff" },
+                        path: { "${params.outdir}/variants/${params.variant_caller}/consensus/${params.consensus_caller}/hiv_resistance/liftoff" },
                         mode: params.publish_dir_mode,
                         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                     ]
                 }
                 withName: 'GFF2JSON' {
                     publishDir = [
-                        path: { "${params.outdir}/variants/${variant_caller}/consensus/${params.consensus_caller}/hiv_resistance/codfreq" },
+                        path: { "${params.outdir}/variants/${params.variant_caller}/consensus/${params.consensus_caller}/hiv_resistance/codfreq" },
                         mode: params.publish_dir_mode,
                         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                     ]
                 }
                 withName: 'CONSENSUS_LIFTOFF' {
                     publishDir = [
-                        path: { "${params.outdir}/variants/${variant_caller}/consensus/${params.consensus_caller}/" },
+                        path: { "${params.outdir}/variants/${params.variant_caller}/consensus/${params.consensus_caller}/" },
                         mode: params.publish_dir_mode,
                         saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
                         enabled: false
@@ -882,14 +802,14 @@ if (!params.skip_variants) {
                 }
                 withName: 'BAM2CODFREQ' {
                     publishDir = [
-                        path: { "${params.outdir}/variants/${variant_caller}/consensus/${params.consensus_caller}/hiv_resistance/codfreq" },
+                        path: { "${params.outdir}/variants/${params.variant_caller}/consensus/${params.consensus_caller}/hiv_resistance/codfreq" },
                         mode: params.publish_dir_mode,
                         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                     ]
                 }
                 withName: 'RESISTANCE_TABLES' {
                     publishDir = [
-                        path: { "${params.outdir}/variants/${variant_caller}/consensus/${params.consensus_caller}/hiv_resistance/resistance_reports" },
+                        path: { "${params.outdir}/variants/${params.variant_caller}/consensus/${params.consensus_caller}/hiv_resistance/resistance_reports" },
                         mode: params.publish_dir_mode,
                         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                     ]
@@ -898,25 +818,25 @@ if (!params.skip_variants) {
                     ext.args  = '--interest_genes "PR,RT;IN"'
                     ext.args2 = '-t 0.9 -q 30 -m 50 -n N'
                     publishDir = [
-                        path: { "${params.outdir}/variants/${variant_caller}/consensus/${params.consensus_caller}/hiv_resistance/resistance_reports" },
+                        path: { "${params.outdir}/variants/${params.variant_caller}/consensus/${params.consensus_caller}/hiv_resistance/resistance_reports" },
                         mode: params.publish_dir_mode,
                         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                     ]
                 }
             }
-            if (params.genome != 'codfreq') {
+
                 process {
                     withName: '.*:.*:HIV_RESISTANCE:HIV_RESISTANCE_ANNOTATION:MAKE_VARIANTS_LONG_TABLE_ADDITIONAL' {
-                        ext.args = "--variant_caller ${variant_caller} --output_file 'liftoff_variants_long_table.csv'"
+                        ext.args = "--variant_caller ${params.variant_caller} --output_file 'liftoff_variants_long_table.csv'"
                         publishDir = [
-                            path: { "${params.outdir}/variants/${variant_caller}/consensus/${params.consensus_caller}/hiv_resistance" },
+                            path: { "${params.outdir}/variants/${params.variant_caller}/consensus/${params.consensus_caller}/hiv_resistance" },
                             mode: params.publish_dir_mode,
                             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                         ]
                     }
                     withName: '.*:.*:HIV_RESISTANCE:HIV_RESISTANCE_ANNOTATION:SNPEFF_BUILD' {
                         publishDir = [
-                            path: { "${params.outdir}/variants/${variant_caller}/consensus/${params.consensus_caller}/hiv_resistance/genome" },
+                            path: { "${params.outdir}/variants/${params.variant_caller}/consensus/${params.consensus_caller}/hiv_resistance/genome" },
                             mode: params.publish_dir_mode,
                             saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
                             enabled: false
@@ -924,7 +844,7 @@ if (!params.skip_variants) {
                     }
                     withName: '.*:.*:HIV_RESISTANCE:HIV_RESISTANCE_ANNOTATION:SNPEFF_ANN' {
                         publishDir = [
-                            path: { "${params.outdir}/variants/${variant_caller}/consensus/${params.consensus_caller}/hiv_resistance/snpeff" },
+                            path: { "${params.outdir}/variants/${params.variant_caller}/consensus/${params.consensus_caller}/hiv_resistance/snpeff" },
                             mode: params.publish_dir_mode,
                             pattern: "*.{csv,txt,html}",
                             enabled: false
@@ -933,7 +853,7 @@ if (!params.skip_variants) {
                     withName: '.*:.*:HIV_RESISTANCE:HIV_RESISTANCE_ANNOTATION:.*:TABIX_BGZIP' {
                         ext.prefix = { "${meta.id}.snpeff" }
                         publishDir = [
-                            path: { "${params.outdir}/variants/${variant_caller}/consensus/${params.consensus_caller}/hiv_resistance/snpeff" },
+                            path: { "${params.outdir}/variants/${params.variant_caller}/consensus/${params.consensus_caller}/hiv_resistance/snpeff" },
                             mode: params.publish_dir_mode,
                             saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
                             enabled: false
@@ -942,7 +862,7 @@ if (!params.skip_variants) {
                     withName: '.*:.*:HIV_RESISTANCE:HIV_RESISTANCE_ANNOTATION:.*:VCF_TABIX_STATS:TABIX_TABIX' {
                         ext.args = '-p vcf -f'
                         publishDir = [
-                            path: { "${params.outdir}/variants/${variant_caller}/consensus/${params.consensus_caller}/hiv_resistance/snpeff" },
+                            path: { "${params.outdir}/variants/${params.variant_caller}/consensus/${params.consensus_caller}/hiv_resistance/snpeff" },
                             mode: params.publish_dir_mode,
                             saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
                             enabled: false
@@ -951,7 +871,7 @@ if (!params.skip_variants) {
                     withName: '.*:.*:HIV_RESISTANCE:HIV_RESISTANCE_ANNOTATION:.*:.*:BCFTOOLS_STATS' {
                         ext.prefix = { "${meta.id}.snpeff" }
                         publishDir = [
-                            path: { "${params.outdir}/variants/${variant_caller}/consensus/${params.consensus_caller}/hiv_resistance/snpeff" },
+                            path: { "${params.outdir}/variants/${params.variant_caller}/consensus/${params.consensus_caller}/hiv_resistance/snpeff" },
                             mode: params.publish_dir_mode,
                             saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
                             enabled: false
@@ -959,7 +879,7 @@ if (!params.skip_variants) {
                     }
                     withName: '.*:.*:HIV_RESISTANCE:HIV_RESISTANCE_ANNOTATION:SNPSIFT_EXTRACTFIELDS' {
                         publishDir = [
-                            path: { "${params.outdir}/variants/${variant_caller}/consensus/${params.consensus_caller}/hiv_resistance/snpeff" },
+                            path: { "${params.outdir}/variants/${params.variant_caller}/consensus/${params.consensus_caller}/hiv_resistance/snpeff" },
                             mode: params.publish_dir_mode,
                             saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
                             enabled: false
@@ -967,23 +887,17 @@ if (!params.skip_variants) {
                     }
                     withName: '.*:.*:HIV_RESISTANCE:HIV_RESISTANCE_ANNOTATION:BCFTOOLS_QUERY' {
                         ext.args = [
-                            variant_caller == 'ivar'     ? "-H -f '%CHROM\\t%POS\\t%REF\\t%ALT\\t%FILTER\\t[%DP\\t]\\t[%REF_DP\\t]\\t[%ALT_DP\\t]\\n'" : '',
-                            variant_caller == 'bcftools' ? "-H -f '%CHROM\\t%POS\\t%REF\\t%ALT\\t%FILTER\\t[%DP\\t]\\t[%AD\\t]\\n'" : '',
+                            params.variant_caller == 'ivar'     ? "-H -f '%CHROM\\t%POS\\t%REF\\t%ALT\\t%FILTER\\t[%DP\\t]\\t[%REF_DP\\t]\\t[%ALT_DP\\t]\\n'" : '',
+                            params.variant_caller == 'bcftools' ? "-H -f '%CHROM\\t%POS\\t%REF\\t%ALT\\t%FILTER\\t[%DP\\t]\\t[%AD\\t]\\n'" : '',
                         ].join(' ').trim()
                         ext.prefix = { "${meta.id}.bcftools_query" }
                         publishDir = [
-                            path: { "${params.outdir}/variants/${variant_caller}/consensus/${params.consensus_caller}/hiv_resistance" },
+                            path: { "${params.outdir}/variants/${params.variant_caller}/consensus/${params.consensus_caller}/hiv_resistance" },
                             enabled: false
                         ]
                     }
                 }
-            }
-        }
-    }
-}
 
-if (!params.skip_assembly) {
-    if (!params.skip_blast) {
         process {
             withName: 'BLAST_MAKEBLASTDB' {
                 ext.args = '-parse_seqids -dbtype nucl'
@@ -995,9 +909,7 @@ if (!params.skip_assembly) {
                 ]
             }
         }
-    }
 
-    if (params.trim_primers && !params.skip_cutadapt) {
         process {
             withName: 'BEDTOOLS_GETFASTA' {
                 ext.args = '-s -nameOnly'
@@ -1027,7 +939,6 @@ if (!params.skip_assembly) {
             }
         }
 
-        if (!params.skip_fastqc) {
             process {
                 withName: '.*:.*:FASTQC' {
                     ext.args = '--quiet'
@@ -1039,10 +950,7 @@ if (!params.skip_assembly) {
                     ]
                 }
             }
-        }
-    }
 
-    if ('spades' in assemblers) {
         process {
             withName: 'SPADES' {
                 ext.args = params.spades_mode ? "--${params.spades_mode}" : ''
@@ -1075,7 +983,6 @@ if (!params.skip_assembly) {
             }
         }
 
-        if (!params.skip_bandage) {
             process {
                 withName: '.*:.*:ASSEMBLY_SPADES:BANDAGE_IMAGE' {
                     ext.args = '--height 1000'
@@ -1086,9 +993,7 @@ if (!params.skip_assembly) {
                     ]
                 }
             }
-        }
 
-        if (!params.skip_blast) {
             process {
                 withName: '.*:.*:ASSEMBLY_SPADES:.*:BLAST_BLASTN' {
                     ext.args = "-outfmt '6 stitle staxids sscinames std slen qlen qcovs'"
@@ -1107,9 +1012,7 @@ if (!params.skip_assembly) {
                     ]
                 }
             }
-        }
 
-        if (!params.skip_assembly_quast) {
             process {
                 withName: '.*:.*:ASSEMBLY_SPADES:.*:QUAST' {
                     ext.prefix = { "${meta.id}.spades" }
@@ -1120,9 +1023,7 @@ if (!params.skip_assembly) {
                     ]
                 }
             }
-        }
 
-        if (!params.skip_abacas) {
             process {
                 withName: '.*:.*:ASSEMBLY_SPADES:.*:ABACAS' {
                     ext.args = '-m -p nucmer'
@@ -1133,9 +1034,7 @@ if (!params.skip_assembly) {
                     ]
                 }
             }
-        }
 
-        if (!params.skip_plasmidid) {
             process {
                 withName: '.*:.*:ASSEMBLY_SPADES:.*:PLASMIDID' {
                     ext.args = '--only-reconstruct -C 47 -S 47 -i 60 --no-trim -k 0.80'
@@ -1146,10 +1045,7 @@ if (!params.skip_assembly) {
                     ]
                 }
             }
-        }
-    }
 
-    if ('unicycler' in assemblers) {
         process {
             withName: 'UNICYCLER' {
                 publishDir = [
@@ -1181,7 +1077,6 @@ if (!params.skip_assembly) {
             }
         }
 
-        if (!params.skip_bandage) {
             process {
                 withName: '.*:.*:ASSEMBLY_UNICYCLER:BANDAGE_IMAGE' {
                     ext.args = '--height 1000'
@@ -1192,9 +1087,7 @@ if (!params.skip_assembly) {
                     ]
                 }
             }
-        }
 
-        if (!params.skip_blast) {
             process {
                 withName: '.*:.*:ASSEMBLY_UNICYCLER:.*:BLAST_BLASTN' {
                     ext.args = "-outfmt '6 stitle staxids sscinames std slen qlen qcovs'"
@@ -1213,9 +1106,7 @@ if (!params.skip_assembly) {
                     ]
                 }
             }
-        }
 
-        if (!params.skip_assembly_quast) {
             process {
                 withName: '.*:.*:ASSEMBLY_UNICYCLER:.*:QUAST' {
                     ext.prefix = { "${meta.id}.unicycler" }
@@ -1226,9 +1117,7 @@ if (!params.skip_assembly) {
                     ]
                 }
             }
-        }
 
-        if (!params.skip_abacas) {
             process {
                 withName: '.*:.*:ASSEMBLY_UNICYCLER:.*:ABACAS' {
                     ext.args = '-m -p nucmer'
@@ -1239,9 +1128,7 @@ if (!params.skip_assembly) {
                     ]
                 }
             }
-        }
 
-        if (!params.skip_plasmidid) {
             process {
                 withName: '.*:.*:ASSEMBLY_UNICYCLER:.*:PLASMIDID' {
                     ext.args = '--only-reconstruct -C 47 -S 47 -i 60 --no-trim -k 0.80'
@@ -1252,10 +1139,7 @@ if (!params.skip_assembly) {
                     ]
                 }
             }
-        }
-    }
 
-    if ('minia' in assemblers) {
         process {
             withName: 'MINIA' {
                 ext.args = '-kmer-size 31 -abundance-min 20'
@@ -1267,7 +1151,6 @@ if (!params.skip_assembly) {
             }
         }
 
-        if (!params.skip_blast) {
             process {
                 withName: '.*:.*:ASSEMBLY_MINIA:.*:BLAST_BLASTN' {
                     ext.args = "-outfmt '6 stitle staxids sscinames std slen qlen qcovs'"
@@ -1286,9 +1169,7 @@ if (!params.skip_assembly) {
                     ]
                 }
             }
-        }
 
-        if (!params.skip_assembly_quast) {
             process {
                 withName: '.*:.*:ASSEMBLY_MINIA:.*:QUAST' {
                     ext.prefix = { "${meta.id}.minia" }
@@ -1299,9 +1180,7 @@ if (!params.skip_assembly) {
                     ]
                 }
             }
-        }
 
-        if (!params.skip_abacas) {
             process {
                 withName: '.*:.*:ASSEMBLY_MINIA:.*:ABACAS' {
                     ext.args = '-m -p nucmer'
@@ -1312,9 +1191,7 @@ if (!params.skip_assembly) {
                     ]
                 }
             }
-        }
 
-        if (!params.skip_plasmidid) {
             process {
                 withName: '.*:.*:ASSEMBLY_MINIA:.*:PLASMIDID' {
                     ext.args = '--only-reconstruct -C 47 -S 47 -i 60 --no-trim -k 0.80'
@@ -1325,11 +1202,7 @@ if (!params.skip_assembly) {
                     ]
                 }
             }
-        }
-    }
-}
 
-if (!params.skip_multiqc) {
     process {
         withName: 'MULTIQC' {
             ext.args   = [
@@ -1357,4 +1230,3 @@ if (!params.skip_multiqc) {
             ]
         }
     }
-}

--- a/conf/modules_illumina.config
+++ b/conf/modules_illumina.config
@@ -15,7 +15,7 @@
 //
 
 process {
-    withName: '.*:.*:PREPARE_GENOME:GUNZIP_.*' {
+    withName: '.*:.*:PREPARE_GENOME_ILLUMINA:GUNZIP_.*' {
         publishDir = [
             path: { "${params.outdir}/genome" },
             mode: params.publish_dir_mode,
@@ -24,7 +24,7 @@ process {
         ]
     }
 
-    withName: '.*:.*:PREPARE_GENOME:UNTAR_.*' {
+    withName: '.*:.*:PREPARE_GENOME_ILLUMINA:UNTAR_.*' {
         ext.args2 = '--no-same-owner'
         publishDir = [
             path: { "${params.outdir}/genome" },
@@ -461,7 +461,7 @@ process {
         }
 
         process {
-            withName: '.*:.*:PREPARE_GENOME:SNPEFF_BUILD' {
+            withName: '.*:.*:PREPARE_GENOME_ILLUMINA:SNPEFF_BUILD' {
                 publishDir = [
                     path: { "${params.outdir}/genome" },
                     mode: params.publish_dir_mode,

--- a/conf/modules_nanopore.config
+++ b/conf/modules_nanopore.config
@@ -108,7 +108,6 @@ process {
 // Optional configuration options
 //
 
-if (params.sequencing_summary && !params.skip_pycoqc) {
     process {
         withName: 'PYCOQC' {
             ext.prefix = 'pycoqc'
@@ -119,9 +118,7 @@ if (params.sequencing_summary && !params.skip_pycoqc) {
             ]
         }
     }
-}
 
-if (!params.skip_nanoplot) {
     process {
         withName: 'NANOPLOT' {
             publishDir = [
@@ -131,9 +128,7 @@ if (!params.skip_nanoplot) {
             ]
         }
     }
-}
 
-if (!params.skip_mosdepth) {
     process {
         withName: 'COLLAPSE_PRIMERS' {
             publishDir = [
@@ -180,9 +175,7 @@ if (!params.skip_mosdepth) {
             ]
         }
     }
-}
 
-if (!params.skip_pangolin) {
     process {
         withName: 'PANGOLIN_RUN' {
             publishDir = [
@@ -205,9 +198,7 @@ if (!params.skip_pangolin) {
             ]
         }
     }
-}
 
-if (!params.skip_nextclade) {
     process {
         withName: 'UNTAR' {
             publishDir = [
@@ -235,9 +226,7 @@ if (!params.skip_nextclade) {
             ]
         }
     }
-}
 
-if (!params.skip_freyja) {
     process {
         withName: 'FREYJA_VARIANTS' {
             publishDir = [
@@ -281,9 +270,7 @@ if (!params.skip_freyja) {
             ]
         }
     }
-}
 
-if (!params.skip_variants_quast) {
     process {
         withName: 'QUAST' {
             publishDir = [
@@ -293,9 +280,7 @@ if (!params.skip_variants_quast) {
             ]
         }
     }
-}
 
-if (!params.skip_snpeff) {
     process {
         withName: 'SNPEFF_BUILD' {
             publishDir = [
@@ -350,7 +335,6 @@ if (!params.skip_snpeff) {
         }
     }
 
-    if (!params.skip_variants_long_table) {
         process {
             withName: 'BCFTOOLS_QUERY' {
                 ext.args = "-H -f '%CHROM\\t%POS\\t%REF\\t%ALT\\t%FILTER\\t[%DP\\t]\\t[%AD\\t]\\n'"
@@ -378,10 +362,7 @@ if (!params.skip_snpeff) {
                 ]
             }
         }
-    }
-}
 
-if (!params.skip_multiqc) {
     process {
         withName: 'MULTIQC' {
             ext.args   = [
@@ -395,4 +376,3 @@ if (!params.skip_multiqc) {
             ]
         }
     }
-}

--- a/main.nf
+++ b/main.nf
@@ -15,35 +15,9 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-def primer_set         = ''
-def primer_set_version = ''
-
-// Make sure platform is defined
-if( !params.platform ) {
-    error "Parameter --platform is required (illumina / nanopore). Please specify."
-}
-
-// Check that platform value is valid
-def valid_platforms = ["illumina","nanopore"]
-if( !(params.platform in valid_platforms) ) {
-    error "Invalid value for --platform: '${params.platform}'. Allowed values: ${valid_platforms.join(', ')}"
-}
-
-if (params.platform == 'illumina' && params.trim_primers) {
-    primer_set         = params.primer_set
-    primer_set_version = params.primer_set_version
-} else if (params.platform == 'nanopore') {
-    primer_set          = params.primer_set
-    primer_set_version  = params.primer_set_version
-    params.artic_scheme = getGenomeAttribute('scheme', primer_set, primer_set_version)
-}
-
-def artic_scheme = params.platform == 'nanopore' ? params.artic_scheme : null
-
 params.fasta         = getGenomeAttribute('fasta')
 params.gff           = getGenomeAttribute('gff')
 params.bowtie2_index = getGenomeAttribute('bowtie2')
-params.primer_bed    = getGenomeAttribute('primer_bed', primer_set, primer_set_version)
 
 params.nextclade_dataset           = getGenomeAttribute('nextclade_dataset_v3pl')
 params.nextclade_dataset_name      = getGenomeAttribute('nextclade_dataset_name')
@@ -75,6 +49,31 @@ workflow NFCORE_VIRALRECON {
 
     main:
 
+    def primer_set         = ''
+    def primer_set_version = ''
+
+    // Make sure platform is defined
+    if( !params.platform ) {
+        error "Parameter --platform is required (illumina / nanopore). Please specify."
+    }
+
+    // Check that platform value is valid
+    def valid_platforms = ["illumina","nanopore"]
+    if( !(params.platform in valid_platforms) ) {
+        error "Invalid value for --platform: '${params.platform}'. Allowed values: ${valid_platforms.join(', ')}"
+    }
+
+    if (params.platform == 'illumina' && params.trim_primers) {
+        primer_set         = params.primer_set
+        primer_set_version = params.primer_set_version
+    } else if (params.platform == 'nanopore') {
+        primer_set          = params.primer_set
+        primer_set_version  = params.primer_set_version
+    }
+
+    def primer_bed   = getGenomeAttribute('primer_bed', primer_set, primer_set_version)
+    def artic_scheme = params.platform == 'nanopore' ? getGenomeAttribute('scheme', primer_set, primer_set_version) : null
+
     //
     // WORKFLOW: Run pipeline
     //
@@ -84,7 +83,7 @@ workflow NFCORE_VIRALRECON {
             samplesheet,
             params.fasta,
             params.gff,
-            params.primer_bed,
+            primer_bed,
             params.bowtie2_index,
             params.nextclade_dataset,
             params.nextclade_dataset_name,

--- a/subworkflows/local/fastq_trim_fastp_fastqc/main.nf
+++ b/subworkflows/local/fastq_trim_fastp_fastqc/main.nf
@@ -9,10 +9,8 @@ include { FASTP                 } from '../../../modules/nf-core/fastp/main'
 //
 // Function that parses fastp json output file to get total number of reads after trimming
 //
-import groovy.json.JsonSlurper
-
 def getFastpReadsAfterFiltering(json_file) {
-    def Map json = (Map) new JsonSlurper().parseText(json_file.text).get('summary')
+    def Map json = new groovy.json.JsonSlurper().parseText(json_file.text).get('summary')
     return json['after_filtering']['total_reads'].toInteger()
 }
 
@@ -49,7 +47,7 @@ workflow FASTQ_TRIM_FASTP_FASTQC {
     fastqc_trim_zip   = channel.empty()
     if (!params.skip_fastp) {
         FASTP (
-            reads.map { meta, reads -> tuple(meta, reads, adapter_fasta) },
+            reads.map { meta, reads_ -> tuple(meta, reads_, adapter_fasta) },
             discard_trimmed_pass,
             save_trimmed_fail,
             save_merged
@@ -68,9 +66,9 @@ workflow FASTQ_TRIM_FASTP_FASTQC {
         trim_reads
             .join(trim_json)
             .map {
-                meta, reads, json ->
+                meta, reads_, json ->
                     if (getFastpReadsAfterFiltering(json) > 0) {
-                        [ meta, reads ]
+                        [ meta, reads_ ]
                     }
             }
             .set { trim_reads }

--- a/subworkflows/local/utils_nfcore_viralrecon_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_viralrecon_pipeline/main.nf
@@ -8,8 +8,6 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-import groovy.json.JsonSlurper
-
 include { UTILS_NFSCHEMA_PLUGIN     } from '../../nf-core/utils_nfschema_plugin'
 include { paramsSummaryMap          } from 'plugin/nf-schema'
 include { samplesheetToList         } from 'plugin/nf-schema'
@@ -296,9 +294,9 @@ def checkPrimerSuffixes(primer_bed_file, primer_left_suffix, primer_right_suffix
         def name = line.split('\t')[3]
         if (name.contains(primer_left_suffix)) {
             left += 1
-        } else if (name.contains(primer_right_suffix)) (
+        } else if (name.contains(primer_right_suffix)) {
             right += 1
-        )
+        }
     }
     if (total != (left + right)) {
         log.warn "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
@@ -348,7 +346,7 @@ def getColFromFile(input_file, col=0, uniqify=false, sep='\t') {
 def getNumLinesInFile(input_file) {
     def num_lines = 0
     input_file.eachLine { line ->
-        num_lines ++
+        num_lines += 1
     }
     return num_lines
 }
@@ -431,19 +429,17 @@ def getFlagstatMappedReads(flagstat_file, params) {
 //
 def isMultiFasta(fasta_file, log) {
     def count = 0
-    def line  = null
-    fasta_file.withReader { reader ->
-        while (line = reader.readLine()) {
-            if (line.contains('>')) {
-                count++
-                if (count > 1) {
-                    log.warn "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
-                        "  This pipeline does not officially support multi-fasta genome files!\n\n" +
-                        "  The parameters and processes are tailored for viral genome analysis.\n" +
-                        "  Please amend the '--fasta' parameter.\n" +
-                        "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-                    break
-                }
+    fasta_file.eachLine { line ->
+        if (count > 1)
+            return
+        if (line.contains('>')) {
+            count += 1
+            if (count > 1) {
+                log.warn "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
+                    "  This pipeline does not officially support multi-fasta genome files!\n\n" +
+                    "  The parameters and processes are tailored for viral genome analysis.\n" +
+                    "  Please amend the '--fasta' parameter.\n" +
+                    "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
             }
         }
     }
@@ -454,21 +450,19 @@ def isMultiFasta(fasta_file, log) {
 //
 def checkIfSwiftProtocol(primer_bed_file, name_prefix, log) {
     def count = 0
-    def line  = null
-    primer_bed_file.withReader { reader ->
-        while (line = reader.readLine()) {
-            def name = line.split('\t')[3]
-            if (name.contains(name_prefix)) {
-                count++
-                if (count > 1) {
-                    log.warn "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
-                        "  Found '${name_prefix}' in the name field of the primer BED file!\n" +
-                        "  This suggests that you have used the SWIFT/SNAP protocol to prep your samples.\n" +
-                        "  If so, please set '--ivar_trim_offset 5' as suggested in the issue below:\n" +
-                        "  https://github.com/nf-core/viralrecon/issues/170\n" +
-                        "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-                    break
-                }
+    primer_bed_file.eachLine { line ->
+        if (count > 1)
+            return
+        def name = line.split('\t')[3]
+        if (name.contains(name_prefix)) {
+            count += 1
+            if (count > 1) {
+                log.warn "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
+                    "  Found '${name_prefix}' in the name field of the primer BED file!\n" +
+                    "  This suggests that you have used the SWIFT/SNAP protocol to prep your samples.\n" +
+                    "  If so, please set '--ivar_trim_offset 5' as suggested in the issue below:\n" +
+                    "  https://github.com/nf-core/viralrecon/issues/170\n" +
+                    "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
             }
         }
     }
@@ -478,7 +472,7 @@ def checkIfSwiftProtocol(primer_bed_file, name_prefix, log) {
 // Function that parses fastp json output file to get total number of reads after trimming
 //
 def getFastpReadsAfterFiltering(json_file) {
-    def Map json = (Map) new JsonSlurper().parseText(json_file.text).get('summary')
+    def Map json = new groovy.json.JsonSlurper().parseText(json_file.text).get('summary')
     return json['after_filtering']['total_reads'].toInteger()
 }
 
@@ -486,6 +480,6 @@ def getFastpReadsAfterFiltering(json_file) {
 // Function that parses fastp json output file to get total number of reads before trimming
 //
 def getFastpReadsBeforeFiltering(json_file) {
-    def Map json = (Map) new JsonSlurper().parseText(json_file.text).get('summary')
+    def Map json = new groovy.json.JsonSlurper().parseText(json_file.text).get('summary')
     return json['before_filtering']['total_reads'].toInteger()
 }

--- a/subworkflows/nf-core/bam_markduplicates_picard/main.nf
+++ b/subworkflows/nf-core/bam_markduplicates_picard/main.nf
@@ -15,7 +15,7 @@ workflow BAM_MARKDUPLICATES_PICARD {
 
     main:
 
-    ch_versions = Channel.empty()
+    ch_versions = channel.empty()
 
     PICARD_MARKDUPLICATES ( ch_reads, ch_fasta, ch_fai )
     ch_versions = ch_versions.mix(PICARD_MARKDUPLICATES.out.versions.first())

--- a/subworkflows/nf-core/bam_sort_stats_samtools/main.nf
+++ b/subworkflows/nf-core/bam_sort_stats_samtools/main.nf
@@ -13,7 +13,7 @@ workflow BAM_SORT_STATS_SAMTOOLS {
 
     main:
 
-    ch_versions = Channel.empty()
+    ch_versions = channel.empty()
 
     SAMTOOLS_SORT ( ch_bam, ch_fasta, '' )
     ch_versions = ch_versions.mix(SAMTOOLS_SORT.out.versions.first())

--- a/subworkflows/nf-core/bam_stats_samtools/main.nf
+++ b/subworkflows/nf-core/bam_stats_samtools/main.nf
@@ -12,7 +12,7 @@ workflow BAM_STATS_SAMTOOLS {
     ch_fasta   // channel: [ val(meta), path(fasta) ]
 
     main:
-    ch_versions = Channel.empty()
+    ch_versions = channel.empty()
 
     SAMTOOLS_STATS ( ch_bam_bai, ch_fasta )
     ch_versions = ch_versions.mix(SAMTOOLS_STATS.out.versions)

--- a/subworkflows/nf-core/fastq_align_bowtie2/main.nf
+++ b/subworkflows/nf-core/fastq_align_bowtie2/main.nf
@@ -15,7 +15,7 @@ workflow FASTQ_ALIGN_BOWTIE2 {
 
     main:
 
-    ch_versions = Channel.empty()
+    ch_versions = channel.empty()
 
     //
     // Map reads with Bowtie2

--- a/workflows/viralrecon.nf
+++ b/workflows/viralrecon.nf
@@ -22,82 +22,6 @@ include { getFastpReadsBeforeFiltering } from '../subworkflows/local/utils_nfcor
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    VALIDATE INPUTS
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-*/
-
-def valid_params = [
-    protocols            : ['metagenomic', 'amplicon'],
-    variant_callers      : ['ivar', 'bcftools'],
-    consensus_callers    : ['ivar', 'bcftools'],
-    assemblers           : ['spades', 'unicycler', 'minia'],
-    spades_modes         : ['rnaviral', 'corona', 'metaviral', 'meta', 'metaplasmid', 'plasmid', 'isolate', 'rna', 'bio'],
-]
-
-def checkPathParamList = []
-
-// Check input path parameters to see if they exist
-if (params.platform == 'illumina') {
-    checkPathParamList = [
-        params.input, params.fasta, params.gff, params.bowtie2_index,
-        params.kraken2_db, params.primer_bed, params.primer_fasta,
-        params.blast_db, params.spades_hmm, params.multiqc_config,
-        params.freyja_barcodes, params.freyja_lineages_meta, params.freyja_lineages_topology, params.additional_annotation
-    ]
-} else if (params.platform == 'nanopore') {
-    checkPathParamList = [
-        params.input, params.fastq_dir,
-        params.sequencing_summary, params.gff,
-        params.freyja_barcodes, params.freyja_lineages_meta, params.freyja_lineages_topology, params.additional_annotation,
-        params.kraken2_db
-    ]
-}
-
-for (param in checkPathParamList) { if (param) { file(param, checkIfExists: true) } }
-
-if (params.input)                 { ch_input          = file(params.input)                 } else { exit 1, 'Input samplesheet file not specified!' }
-if (params.spades_hmm)            { ch_spades_hmm     = file(params.spades_hmm)            } else { ch_spades_hmm = []                              }
-if (params.additional_annotation) { ch_additional_gtf = file(params.additional_annotation) } else { ch_additional_gtf = channel.empty()             }
-if (params.taxidlist)             { ch_taxidlist      = file(params.taxidlist)             } else { ch_taxidlist = []                               }
-
-// If protocol amplicon you must provide primer set information
-if (params.protocol == 'amplicon' && !params.skip_variants && !params.primer_bed) {
-    error("To perform variant calling in amplicon mode please provide a valid primer BED file e.g. '--primer_bed primers.bed'.")
-}
-
-if (!params.fasta) {
-    error("Genome fasta file not specified with e.g. '--fasta genome.fa' or via a detectable config file.")
-}
-
-if (!params.skip_kraken2 && !params.kraken2_db) {
-    if (!params.kraken2_db_name) {
-        error("Please specify a valid name to build Kraken2 database for host e.g. '--kraken2_db_name human'.")
-    }
-}
-
-def assemblers = params.assemblers ? params.assemblers.split(',').collect{ it.trim().toLowerCase() } : []
-
-def variant_caller = params.variant_caller
-if (!variant_caller) { variant_caller = params.trim_primers ? 'ivar' : 'bcftools' }
-
-if (params.sequencing_summary)      { ch_sequencing_summary = file(params.sequencing_summary)      } else { ch_sequencing_summary = [] }
-
-// Need to stage artic model properly depending on whether it is a string or a file
-ch_artic_model_dir = params.artic_minion_model_dir ? channel.value(file(params.artic_minion_model_dir, type: 'dir')) :  []
-
-/*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    CONFIG FILES
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-*/
-
-// Header files
-ch_blast_outfmt6_header          = file("$projectDir/assets/headers/blast_outfmt6_header.txt", checkIfExists: true)
-ch_blast_filtered_outfmt6_header = file("$projectDir/assets/headers/blast_filtered_outfmt6_header.txt", checkIfExists: true)
-ch_ivar_variants_header_mqc      = file("$projectDir/assets/headers/ivar_variants_header_mqc.txt", checkIfExists: true)
-
-/*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     IMPORT LOCAL MODULES/SUBWORKFLOWS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
@@ -112,11 +36,8 @@ include { PREPARE_PRIMER_FASTA                                    } from '../mod
 //
 // SUBWORKFLOW: Consisting of a mix of local and nf-core/modules
 //
-if (params.platform == 'illumina') {
-    include { PREPARE_GENOME_ILLUMINA as PREPARE_GENOME } from '../subworkflows/local/prepare_genome_illumina'
-} else if (params.platform == 'nanopore') {
-    include { PREPARE_GENOME_NANOPORE as PREPARE_GENOME } from '../subworkflows/local/prepare_genome_nanopore'
-}
+include { PREPARE_GENOME_ILLUMINA } from '../subworkflows/local/prepare_genome_illumina'
+include { PREPARE_GENOME_NANOPORE } from '../subworkflows/local/prepare_genome_nanopore'
 
 include { VARIANTS_IVAR           } from '../subworkflows/local/variants_ivar'
 include { VARIANTS_BCFTOOLS       } from '../subworkflows/local/variants_bcftools'
@@ -178,12 +99,6 @@ include { BAM_VARIANT_DEMIX_BOOT_FREYJA } from '../subworkflows/nf-core/bam_vari
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-// Info required for completion email and summary
-def pass_mapped_reads  = [:]
-def fail_mapped_reads  = [:]
-def pass_barcode_reads = [:]
-def fail_barcode_reads = [:]
-
 workflow VIRALRECON {
 
     take:
@@ -198,6 +113,90 @@ workflow VIRALRECON {
     ch_artic_scheme
 
     main:
+    /*
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        VALIDATE INPUTS
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    */
+
+    def valid_params = [
+        protocols            : ['metagenomic', 'amplicon'],
+        variant_callers      : ['ivar', 'bcftools'],
+        consensus_callers    : ['ivar', 'bcftools'],
+        assemblers           : ['spades', 'unicycler', 'minia'],
+        spades_modes         : ['rnaviral', 'corona', 'metaviral', 'meta', 'metaplasmid', 'plasmid', 'isolate', 'rna', 'bio'],
+    ]
+
+    def checkPathParamList = []
+
+    // Check input path parameters to see if they exist
+    if (params.platform == 'illumina') {
+        checkPathParamList = [
+            params.input, params.fasta, params.gff, params.bowtie2_index,
+            params.kraken2_db, params.primer_bed, params.primer_fasta,
+            params.blast_db, params.spades_hmm, params.multiqc_config,
+            params.freyja_barcodes, params.freyja_lineages_meta, params.freyja_lineages_topology, params.additional_annotation
+        ]
+    } else if (params.platform == 'nanopore') {
+        checkPathParamList = [
+            params.input, params.fastq_dir,
+            params.sequencing_summary, params.gff,
+            params.freyja_barcodes, params.freyja_lineages_meta, params.freyja_lineages_topology, params.additional_annotation,
+            params.kraken2_db
+        ]
+    }
+
+    checkPathParamList.each { param ->
+        if (param) { file(param, checkIfExists: true) }
+    }
+
+    if (params.input)                 { ch_input          = file(params.input)                 } else { exit 1, 'Input samplesheet file not specified!' }
+    if (params.spades_hmm)            { ch_spades_hmm     = file(params.spades_hmm)            } else { ch_spades_hmm = []                              }
+    if (params.additional_annotation) { ch_additional_gtf = file(params.additional_annotation) } else { ch_additional_gtf = channel.empty()             }
+    if (params.taxidlist)             { ch_taxidlist      = file(params.taxidlist)             } else { ch_taxidlist = []                               }
+
+    // If protocol amplicon you must provide primer set information
+    if (params.protocol == 'amplicon' && !params.skip_variants && !params.primer_bed) {
+        error("To perform variant calling in amplicon mode please provide a valid primer BED file e.g. '--primer_bed primers.bed'.")
+    }
+
+    if (!params.fasta) {
+        error("Genome fasta file not specified with e.g. '--fasta genome.fa' or via a detectable config file.")
+    }
+
+    if (!params.skip_kraken2 && !params.kraken2_db) {
+        if (!params.kraken2_db_name) {
+            error("Please specify a valid name to build Kraken2 database for host e.g. '--kraken2_db_name human'.")
+        }
+    }
+
+    def assemblers = params.assemblers ? params.assemblers.split(',').collect{ it.trim().toLowerCase() } : []
+
+    def variant_caller = params.variant_caller
+    if (!variant_caller) { variant_caller = params.trim_primers ? 'ivar' : 'bcftools' }
+
+    if (params.sequencing_summary)      { ch_sequencing_summary = file(params.sequencing_summary)      } else { ch_sequencing_summary = [] }
+
+    // Need to stage artic model properly depending on whether it is a string or a file
+    ch_artic_model_dir = params.artic_minion_model_dir ? channel.value(file(params.artic_minion_model_dir, type: 'dir')) :  []
+
+    /*
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        CONFIG FILES
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    */
+
+    // Header files
+    ch_blast_outfmt6_header          = file("$projectDir/assets/headers/blast_outfmt6_header.txt", checkIfExists: true)
+    ch_blast_filtered_outfmt6_header = file("$projectDir/assets/headers/blast_filtered_outfmt6_header.txt", checkIfExists: true)
+    ch_ivar_variants_header_mqc      = file("$projectDir/assets/headers/ivar_variants_header_mqc.txt", checkIfExists: true)
+
+    // Info required for completion email and summary
+    def pass_mapped_reads  = [:]
+    def fail_mapped_reads  = [:]
+    def pass_barcode_reads = [:]
+    def fail_barcode_reads = [:]
+
     ch_versions      = channel.empty()
     ch_multiqc_files = channel.empty()
     multiqc_report   = channel.empty()
@@ -205,16 +204,28 @@ workflow VIRALRECON {
     //
     // SUBWORKFLOW: Uncompress and prepare reference genome files
     //
-    PREPARE_GENOME (
-        ch_genome_fasta,
-        ch_genome_gff,
-        ch_primer_bed,
-        ch_bowtie2_index,
-        ch_nextclade_dataset,
-        ch_nextclade_dataset_name,
-        ch_nextclade_dataset_tag
-    )
-    ch_versions = ch_versions.mix(PREPARE_GENOME.out.versions)
+    if (params.platform == 'illumina') {
+        genome = PREPARE_GENOME_ILLUMINA (
+            ch_genome_fasta,
+            ch_genome_gff,
+            ch_primer_bed,
+            ch_bowtie2_index,
+            ch_nextclade_dataset,
+            ch_nextclade_dataset_name,
+            ch_nextclade_dataset_tag
+        )
+    } else if (params.platform == 'nanopore') {
+        genome = PREPARE_GENOME_NANOPORE (
+            ch_genome_fasta,
+            ch_genome_gff,
+            ch_primer_bed,
+            ch_bowtie2_index,
+            ch_nextclade_dataset,
+            ch_nextclade_dataset_name,
+            ch_nextclade_dataset_tag
+        )
+    }
+    ch_versions = ch_versions.mix(genome.versions)
 
     if (params.platform == 'illumina') {
         //
@@ -222,37 +233,32 @@ workflow VIRALRECON {
         //
 
         // Check genome fasta only contains a single contig
-        PREPARE_GENOME
-            .out
+        genome
             .fasta
             .map { isMultiFasta(it, log) }
 
         if (params.trim_primers && !params.skip_variants) {
             // Check primer BED file only contains suffixes provided --primer_left_suffix / --primer_right_suffix
-            PREPARE_GENOME
-                .out
+            genome
                 .primer_bed
                 .map { checkPrimerSuffixes(it, params.primer_left_suffix, params.primer_right_suffix, log) }
 
             // Check whether the contigs in the primer BED file are present in the reference genome
-            PREPARE_GENOME
-                .out
+            genome
                 .primer_bed
-                .map { [ getColFromFile(it, col=0, uniqify=true, sep='\t') ] }
+                .map { [ getColFromFile(it, 0, true) ] }
                 .set { ch_bed_contigs }
 
-            PREPARE_GENOME
-                .out
+            genome
                 .fai
-                .map { [ getColFromFile(it, col=0, uniqify=true, sep='\t') ] }
+                .map { [ getColFromFile(it, 0, true) ] }
                 .concat(ch_bed_contigs)
                 .collect()
                 .map { fai, bed -> checkContigsInBED(fai, bed, log) }
 
             // Check whether the primer BED file supplied to the pipeline is from the SWIFT/SNAP protocol
             if (!params.ivar_trim_offset) {
-                PREPARE_GENOME
-                    .out
+                genome
                     .primer_bed
                     .map { checkIfSwiftProtocol(it, 'covid19genome', log) }
             }
@@ -329,7 +335,7 @@ workflow VIRALRECON {
         if (!params.skip_kraken2) {
             KRAKEN2_KRAKEN2 (
                 ch_variants_fastq,
-                PREPARE_GENOME.out.kraken2_db,
+                genome.kraken2_db,
                 params.kraken2_variants_host_filter || params.kraken2_assembly_host_filter,
                 params.kraken2_variants_host_filter || params.kraken2_assembly_host_filter
             )
@@ -353,10 +359,10 @@ workflow VIRALRECON {
         if (!params.skip_variants) {
             FASTQ_ALIGN_BOWTIE2 (
                 ch_variants_fastq,
-                PREPARE_GENOME.out.bowtie2_index,
+                genome.bowtie2_index,
                 params.save_unaligned,
                 false,
-                PREPARE_GENOME.out.fasta.map { [ [:], it ] }
+                genome.fasta.map { [ [:], it ] }
             )
         ch_bam           = FASTQ_ALIGN_BOWTIE2.out.bam
         ch_bai           = FASTQ_ALIGN_BOWTIE2.out.bai
@@ -415,8 +421,8 @@ workflow VIRALRECON {
         if (!params.skip_variants && !params.skip_ivar_trim && params.trim_primers) {
             BAM_TRIM_PRIMERS_IVAR (
                 ch_bam.join(ch_bai, by: [0]),
-                PREPARE_GENOME.out.primer_bed,
-                PREPARE_GENOME.out.fasta.map { [ [:], it ] }
+                genome.primer_bed,
+                genome.fasta.map { [ [:], it ] }
             )
             ch_bam           = BAM_TRIM_PRIMERS_IVAR.out.bam
             ch_bai           = BAM_TRIM_PRIMERS_IVAR.out.bai
@@ -430,8 +436,8 @@ workflow VIRALRECON {
         if (!params.skip_variants && !params.skip_markduplicates) {
             BAM_MARKDUPLICATES_PICARD (
                 ch_bam,
-                PREPARE_GENOME.out.fasta.map { [ [:], it ] },
-                PREPARE_GENOME.out.fai
+                genome.fasta.map { [ [:], it ] },
+                genome.fai
             )
             ch_bam           = BAM_MARKDUPLICATES_PICARD.out.bam
             ch_bai           = BAM_MARKDUPLICATES_PICARD.out.bai
@@ -445,7 +451,7 @@ workflow VIRALRECON {
         if (!params.skip_variants && !params.skip_picard_metrics) {
             PICARD_COLLECTMULTIPLEMETRICS (
                 ch_bam.join(ch_bai, by: [0]),
-                PREPARE_GENOME.out.fasta.map { [ [:], it ] },
+                genome.fasta.map { [ [:], it ] },
                 [ [:], [] ]
             )
             ch_versions = ch_versions.mix(PICARD_COLLECTMULTIPLEMETRICS.out.versions.first())
@@ -471,7 +477,7 @@ workflow VIRALRECON {
                 MOSDEPTH_AMPLICON (
                     ch_bam
                         .join(ch_bai, by: [0])
-                        .combine(PREPARE_GENOME.out.primer_collapsed_bed),
+                        .combine(genome.primer_collapsed_bed),
                     [ [:], [] ],
                 )
                 ch_versions = ch_versions.mix(MOSDEPTH_AMPLICON.out.versions.first())
@@ -492,13 +498,13 @@ workflow VIRALRECON {
         if (!params.skip_variants && variant_caller == 'ivar') {
             VARIANTS_IVAR (
                 ch_bam,
-                PREPARE_GENOME.out.fasta,
-                (params.trim_primers || !params.skip_markduplicates) ? PREPARE_GENOME.out.fai : [],
-                (params.trim_primers || !params.skip_markduplicates) ? PREPARE_GENOME.out.chrom_sizes : [],
-                ch_genome_gff ? PREPARE_GENOME.out.gff : [],
-                (params.trim_primers && ch_primer_bed) ? PREPARE_GENOME.out.primer_bed : [],
-                PREPARE_GENOME.out.snpeff_db,
-                PREPARE_GENOME.out.snpeff_config,
+                genome.fasta,
+                (params.trim_primers || !params.skip_markduplicates) ? genome.fai : [],
+                (params.trim_primers || !params.skip_markduplicates) ? genome.chrom_sizes : [],
+                ch_genome_gff ? genome.gff : [],
+                (params.trim_primers && ch_primer_bed) ? genome.primer_bed : [],
+                genome.snpeff_db,
+                genome.snpeff_config,
                 ch_ivar_variants_header_mqc
             )
             ch_vcf           = VARIANTS_IVAR.out.vcf
@@ -516,12 +522,12 @@ workflow VIRALRECON {
         if (!params.skip_variants && variant_caller == 'bcftools') {
             VARIANTS_BCFTOOLS (
                 ch_bam,
-                PREPARE_GENOME.out.fasta,
-                (params.trim_primers || !params.skip_markduplicates) ? PREPARE_GENOME.out.chrom_sizes : [],
-                ch_genome_gff ? PREPARE_GENOME.out.gff : [],
-                (params.trim_primers && ch_primer_bed) ? PREPARE_GENOME.out.primer_bed : [],
-                PREPARE_GENOME.out.snpeff_db,
-                PREPARE_GENOME.out.snpeff_config
+                genome.fasta,
+                (params.trim_primers || !params.skip_markduplicates) ? genome.chrom_sizes : [],
+                ch_genome_gff ? genome.gff : [],
+                (params.trim_primers && ch_primer_bed) ? genome.primer_bed : [],
+                genome.snpeff_db,
+                genome.snpeff_config
             )
             ch_vcf           = VARIANTS_BCFTOOLS.out.vcf
             ch_tbi           = VARIANTS_BCFTOOLS.out.tbi
@@ -537,7 +543,7 @@ workflow VIRALRECON {
         if (!params.skip_variants && !params.skip_freyja) {
             BAM_VARIANT_DEMIX_BOOT_FREYJA(
                 ch_bam,
-                PREPARE_GENOME.out.fasta,
+                genome.fasta,
                 params.skip_freyja_boot,
                 params.freyja_repeats,
                 params.freyja_db_name,
@@ -558,9 +564,9 @@ workflow VIRALRECON {
         if (!params.skip_variants && !params.skip_consensus && params.consensus_caller == 'ivar') {
             CONSENSUS_IVAR (
                 ch_bam,
-                PREPARE_GENOME.out.fasta,
-                ch_genome_gff ? PREPARE_GENOME.out.gff.map { [ [:], it ] } : [ [:], [] ],
-                PREPARE_GENOME.out.nextclade_db
+                genome.fasta,
+                ch_genome_gff ? genome.gff.map { [ [:], it ] } : [ [:], [] ],
+                genome.nextclade_db
             )
             ch_nextclade_report = CONSENSUS_IVAR.out.nextclade_report
             ch_pangolin_report  = CONSENSUS_IVAR.out.pangolin_report
@@ -578,9 +584,9 @@ workflow VIRALRECON {
                 ch_bam,
                 ch_vcf,
                 ch_tbi,
-                PREPARE_GENOME.out.fasta,
-                ch_genome_gff ? PREPARE_GENOME.out.gff.map { [ [:], it ] } : [ [:], [] ],
-                PREPARE_GENOME.out.nextclade_db
+                genome.fasta,
+                ch_genome_gff ? genome.gff.map { [ [:], it ] } : [ [:], [] ],
+                genome.nextclade_db
             )
 
             ch_nextclade_report = CONSENSUS_BCFTOOLS.out.nextclade_report
@@ -647,7 +653,7 @@ workflow VIRALRECON {
             ADDITIONAL_ANNOTATION (
                 ch_vcf,
                 ch_tbi,
-                PREPARE_GENOME.out.fasta,
+                genome.fasta,
                 ch_annot,
                 ch_pangolin_report
 
@@ -663,8 +669,8 @@ workflow VIRALRECON {
             HIV_RESISTANCE (
                 ch_consensus_genome,
                 ch_bam.join(ch_bai, by: [0]),
-                PREPARE_GENOME.out.fasta,
-                PREPARE_GENOME.out.gff,
+                genome.fasta,
+                genome.gff,
                 ch_vcf,
                 ch_tbi,
                 ch_pangolin_report,
@@ -677,10 +683,10 @@ workflow VIRALRECON {
         // MODULE: Primer trimming with Cutadapt
         //
         if (params.trim_primers && !params.skip_assembly && !params.skip_cutadapt) {
-            ch_primers =  PREPARE_GENOME.out.primer_fasta.collect { it[1] }
+            ch_primers =  genome.primer_fasta.collect { it[1] }
             if (!params.skip_noninternal_primers){
                 PREPARE_PRIMER_FASTA(
-                    PREPARE_GENOME.out.primer_fasta.collect { it[1] }
+                    genome.primer_fasta.collect { it[1] }
                     )
                 ch_primers = PREPARE_PRIMER_FASTA.out.adapters
             }
@@ -709,9 +715,9 @@ workflow VIRALRECON {
                 ch_assembly_fastq.map { meta, fastq -> [ meta, fastq, [], [] ] },
                 params.spades_mode,
                 ch_spades_hmm,
-                PREPARE_GENOME.out.fasta,
-                ch_genome_gff ? PREPARE_GENOME.out.gff.map { [ [:], it ] } : [ [:], [] ],
-                PREPARE_GENOME.out.blast_db,
+                genome.fasta,
+                ch_genome_gff ? genome.gff.map { [ [:], it ] } : [ [:], [] ],
+                genome.blast_db,
                 ch_blast_outfmt6_header,
                 ch_blast_filtered_outfmt6_header,
                 ch_taxidlist
@@ -726,9 +732,9 @@ workflow VIRALRECON {
         if (!params.skip_assembly && 'unicycler' in assemblers) {
             ASSEMBLY_UNICYCLER (
                 ch_assembly_fastq.map { meta, fastq -> [ meta, fastq, [] ] },
-                PREPARE_GENOME.out.fasta,
-                ch_genome_gff ? PREPARE_GENOME.out.gff.map { [ [:], it ] } : [ [:], [] ],
-                PREPARE_GENOME.out.blast_db,
+                genome.fasta,
+                ch_genome_gff ? genome.gff.map { [ [:], it ] } : [ [:], [] ],
+                genome.blast_db,
                 ch_blast_outfmt6_header,
                 ch_blast_filtered_outfmt6_header,
                 ch_taxidlist
@@ -743,9 +749,9 @@ workflow VIRALRECON {
         if (!params.skip_assembly && 'minia' in assemblers) {
             ASSEMBLY_MINIA (
                 ch_assembly_fastq,
-                PREPARE_GENOME.out.fasta,
-                ch_genome_gff ? PREPARE_GENOME.out.gff.map { [ [:], it ] } : [ [:], [] ],
-                PREPARE_GENOME.out.blast_db,
+                genome.fasta,
+                ch_genome_gff ? genome.gff.map { [ [:], it ] } : [ [:], [] ],
+                genome.blast_db,
                 ch_blast_outfmt6_header,
                 ch_blast_filtered_outfmt6_header,
                 ch_taxidlist
@@ -771,22 +777,19 @@ workflow VIRALRECON {
         }
 
         // Check primer BED file only contains suffixes provided --primer_left_suffix / --primer_right_suffix
-        PREPARE_GENOME
-            .out
+        genome
             .primer_bed
             .map { checkPrimerSuffixes(it, params.primer_left_suffix, params.primer_right_suffix, log) }
 
         // Check whether the contigs in the primer BED file are present in the reference genome
-        PREPARE_GENOME
-            .out
+        genome
             .primer_bed
-            .map { [ getColFromFile(it, col=0, uniqify=true, sep='\t') ] }
+            .map { [ getColFromFile(it, 0, true) ] }
             .set { ch_bed_contigs }
 
-        PREPARE_GENOME
-            .out
+        genome
             .fai
-            .map { [ getColFromFile(it, col=0, uniqify=true, sep='\t') ] }
+            .map { [ getColFromFile(it, 0, true) ] }
             .concat(ch_bed_contigs)
             .collect()
             .map { fai, bed -> checkContigsInBED(fai, bed, log) }
@@ -799,7 +802,7 @@ workflow VIRALRECON {
                 .filter( ~/.*barcode[0-9]{1,4}$/ )
                 .map { dir ->
                     def count = 0
-                    for (x in dir.listFiles()) {
+                    dir.listFiles().each { x ->
                         if (x.isFile() && x.toString().contains('.fastq')) {
                             count += x.countFastq()
                         }
@@ -924,7 +927,7 @@ workflow VIRALRECON {
         if (!params.skip_kraken2) {
             KRAKEN2_KRAKEN2 (
                 ch_variants_fastq,
-                PREPARE_GENOME.out.kraken2_db,
+                genome.kraken2_db,
                 params.kraken2_variants_host_filter || params.kraken2_assembly_host_filter,
                 params.kraken2_variants_host_filter || params.kraken2_assembly_host_filter
             )
@@ -987,8 +990,8 @@ workflow VIRALRECON {
             ARTIC_GUPPYPLEX.out.fastq.filter { it[-1].countFastq() > params.min_guppyplex_reads },
             ch_artic_model_dir,
             params.artic_minion_model,
-            PREPARE_GENOME.out.fasta,
-            PREPARE_GENOME.out.primer_bed
+            genome.fasta,
+            genome.primer_bed
         )
         ch_multiqc_files = ch_multiqc_files.mix(ARTIC_MINION.out.json.collect{it[1]}.ifEmpty([]))
         ch_versions      = ch_versions.mix(ARTIC_MINION.out.versions.first())
@@ -1115,7 +1118,7 @@ workflow VIRALRECON {
             MOSDEPTH_AMPLICON (
                 ch_filtered_bam_nanopore
                     .join(ch_filtered_bai_nanopore, by: [0])
-                    .combine(PREPARE_GENOME.out.primer_collapsed_bed),
+                    .combine(genome.primer_collapsed_bed),
                 [ [:], [] ]
            )
 
@@ -1165,7 +1168,7 @@ workflow VIRALRECON {
         if (!params.skip_nextclade) {
             NEXTCLADE_RUN (
                 ARTIC_MINION.out.fasta,
-                PREPARE_GENOME.out.nextclade_db.collect()
+                genome.nextclade_db.collect()
             )
             ch_versions = ch_versions.mix(NEXTCLADE_RUN.out.versions.first())
 
@@ -1199,7 +1202,7 @@ workflow VIRALRECON {
         if (!params.skip_freyja) {
             BAM_VARIANT_DEMIX_BOOT_FREYJA(
                 ch_filtered_bam_nanopore,
-                PREPARE_GENOME.out.fasta,
+                genome.fasta,
                 params.skip_freyja_boot,
                 params.freyja_repeats,
                 params.freyja_db_name,
@@ -1220,8 +1223,8 @@ workflow VIRALRECON {
                 .set { ch_to_quast }
             QUAST (
                 ch_to_quast,
-                PREPARE_GENOME.out.fasta.collect().map { [ [:], it ] },
-                ch_genome_gff ? PREPARE_GENOME.out.gff.map { [ [:], it ] } : [ [:], [] ],
+                genome.fasta.collect().map { [ [:], it ] },
+                ch_genome_gff ? genome.gff.map { [ [:], it ] } : [ [:], [] ],
             )
             ch_multiqc_files = ch_multiqc_files.mix(QUAST.out.results.collect{it[1]}.ifEmpty([]))
             ch_versions      = ch_versions.mix(QUAST.out.versions)
@@ -1234,9 +1237,9 @@ workflow VIRALRECON {
         if (ch_genome_gff && !params.skip_snpeff) {
             SNPEFF_SNPSIFT (
                 VCFLIB_VCFUNIQ.out.vcf,
-                PREPARE_GENOME.out.snpeff_db.collect(),
-                PREPARE_GENOME.out.snpeff_config.collect(),
-                PREPARE_GENOME.out.fasta.collect()
+                genome.snpeff_db.collect(),
+                genome.snpeff_config.collect(),
+                genome.fasta.collect()
             )
             ch_multiqc_files  = ch_multiqc_files.mix(SNPEFF_SNPSIFT.out.csv.collect{it[1]}.ifEmpty([]))
             ch_snpsift_txt    = SNPEFF_SNPSIFT.out.snpsift_txt
@@ -1277,7 +1280,7 @@ workflow VIRALRECON {
             ADDITIONAL_ANNOTATION (
                 VCFLIB_VCFUNIQ.out.vcf,
                 TABIX_TABIX.out.tbi,
-                PREPARE_GENOME.out.fasta,
+                genome.fasta,
                 ch_annot,
                 ch_pangolin_multiqc
 


### PR DESCRIPTION
Hi,

We are preparing the Nextflow 26.04 release, which will enable strict syntax by default.  Since viralrecon is one of the nf-core pipelines we like to use to battle-test Nextflow, I thought I might try to bring it into strict compliance

NOTE: I have zero domain knowledge of this pipeline! I simply refactored syntax as needed to satisfy the linter with minimal changes. Make sure to validate these changes for correctness.

Tagging @speizerj since I saw your implementation plan for strict syntax -- let me know if these changes make sense to you

Summary:
- Move top-level script statements into workflows (main script, VIRALRECON)
- Replace conditional include with conditional process call
- Replace for/while loops with equivalent methods
- Remove if statements from config -- this should work without creating loads of false warnings, because the strict syntax can validate selectors against conditional processes even if they aren't called in a run

Happy to answer any questions that you might have